### PR TITLE
Поправить конфиг: свойства font и line-height должны быть в самом начале

### DIFF
--- a/.csscomb.json
+++ b/.csscomb.json
@@ -9,6 +9,22 @@
     "strip-spaces": true,
     "sort-order": [
         [
+            "font",
+            "font-family",
+            "font-size",
+            "font-weight",
+            "font-style",
+            "font-variant",
+            "font-size-adjust",
+            "font-stretch",
+            "font-effect",
+            "font-emphasize",
+            "font-emphasize-position",
+            "font-emphasize-style",
+            "font-smooth",
+            "line-height"
+        ],
+        [
             "position",
             "z-index",
             "top",
@@ -301,22 +317,6 @@
             "filter:progid:DXImageTransform.Microsoft.gradient",
             "-ms-filter:\\'progid:DXImageTransform.Microsoft.gradient",
             "text-shadow"
-        ],
-        [
-            "font",
-            "font-family",
-            "font-size",
-            "font-weight",
-            "font-style",
-            "font-variant",
-            "font-size-adjust",
-            "font-stretch",
-            "font-effect",
-            "font-emphasize",
-            "font-emphasize-position",
-            "font-emphasize-style",
-            "font-smooth",
-            "line-height"
         ]
     ]
 }


### PR DESCRIPTION
Перенесла секцию про шрифты в конфиге вверх

ишью https://github.com/csscomb/csscomb.js/issues/16
