### PR TITLE
Fix syntax detecting (#99)

### DIFF
--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -11,6 +11,7 @@ var doNothing = function() {};
  * @name Comb
  */
 var Comb = function() {
+    this.SUPPORTED_SYNTAXES = ['css', 'scss', 'less'];
     this._options = [
         'remove-empty-rulesets',
         'always-semicolon',
@@ -130,8 +131,7 @@ Comb.prototype = {
      */
     processFile: function(path) {
         var _this = this;
-        // TODO: Move extension check into `_shouldProcess` method
-        if (this._shouldProcess(path) && path.match(/\.[css, scss]$/)) {
+        if (this._shouldProcessFile(path)) {
             return vfs.read(path, 'utf8').then(function(data) {
                 var syntax = path.split('.').pop();
                 var processedData = _this.processString(data, syntax, path);
@@ -168,17 +168,15 @@ Comb.prototype = {
         return vfs.listDir(path).then(function(filenames) {
             return vow.all(filenames.map(function(filename) {
                 var fullname = path + '/' + filename;
-                if (_this._shouldProcess(fullname)) {
-                    return vfs.stat(fullname).then(function(stat) {
-                        if (stat.isDirectory()) {
-                            return _this.processDirectory(fullname);
-                        } else if (fullname.match(/\.css$/)) {
-                            return vow.when(_this.processFile(fullname)).then(function(errors) {
-                                if (errors) return errors;
-                            });
-                        }
-                    });
-                }
+                return vfs.stat(fullname).then(function(stat) {
+                    if (stat.isDirectory()) {
+                        return _this._shouldProcess(fullname) && _this.processDirectory(fullname);
+                    } else {
+                        return vow.when(_this.processFile(fullname)).then(function(errors) {
+                            if (errors) return errors;
+                        });
+                    }
+                });
             })).then(function(results) {
                 return [].concat.apply([], results);
             });
@@ -223,8 +221,24 @@ Comb.prototype = {
             if (exclude[i].match(path)) return false;
         }
         return true;
-    }
+    },
 
+    /**
+     * Returns true if specified path is not in excluded list and has one of
+     * acceptable extensions.
+     *
+     * @returns {Boolean}
+     */
+    _shouldProcessFile: function(path) {
+        // Get file's extension:
+        var syntax = path.split('.').pop();
+        // Check if syntax is supported. If not, ignore the file:
+        if (this.SUPPORTED_SYNTAXES.indexOf(syntax) < 0) {
+            return false;
+        }
+
+        return this._shouldProcess(path);
+    }
 };
 
 module.exports = Comb;

--- a/test/csscomb.js
+++ b/test/csscomb.js
@@ -1,0 +1,43 @@
+var Comb = require('../lib/csscomb');
+var assert = require('assert');
+
+describe('csscomb methods', function() {
+    var comb;
+
+    beforeEach(function() {
+        comb = new Comb();
+        comb.configure({ exclude: ['nani/*', 'foo', 'b.css'] });
+    });
+
+    it('shouldProcess(path)', function() {
+        assert.equal(true, comb._shouldProcess('styles'));
+    });
+
+    it('shouldProcess(excluded path)', function() {
+        assert.equal(false, comb._shouldProcess('foo'));
+    });
+
+    it('shouldProcessFile(css)', function() {
+        assert.equal(true, comb._shouldProcessFile('a.css'));
+    });
+
+    it('shouldProcessFile(scss)', function() {
+        assert.equal(true, comb._shouldProcessFile('a.scss'));
+    });
+
+    it('shouldProcessFile(less)', function() {
+        assert.equal(true, comb._shouldProcessFile('a.less'));
+    });
+
+    it('shouldProcessFile(txt)', function() {
+        assert.equal(false, comb._shouldProcessFile('a.txt'));
+    });
+
+    it('shouldProcessFile(css, excluded directory)', function() {
+        assert.equal(false, comb._shouldProcessFile('nani/a.css'));
+    });
+
+    it('shouldProcessFile(css, excluded file)', function() {
+        assert.equal(false, comb._shouldProcessFile('b.css'));
+    });
+});


### PR DESCRIPTION
Get file's extension and check if it's present in a list of supported syntaxes.
If not, print an error.

![tumblr_msq32tmwsc1ssucqko1_400](https://f.cloud.github.com/assets/872004/1491460/397427a4-47af-11e3-877d-c5e6b683325d.gif)
