### PR TITLE
Tests: Change mocha reporter `spec` -> `dot`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
         "csscomb": "./bin/csscomb"
     },
     "scripts": {
-        "test": "./node_modules/.bin/jshint-groups && ./node_modules/.bin/jscs . && ./node_modules/.bin/mocha -u bdd -R spec"
+        "test": "./node_modules/.bin/jshint-groups && ./node_modules/.bin/jscs . && ./node_modules/.bin/mocha -u bdd -R dot"
     }
 }


### PR DESCRIPTION
We've already discussed reporters here: #90 
I chose `dot` over `nyan` because the latter visually breaks with multi-line `console.log` outputs:

![screen shot 2013-11-13 at 18 11 15](https://f.cloud.github.com/assets/872004/1531897/bea10d7a-4c6e-11e3-9bc1-6ced672888a0.png)
![screen shot 2013-11-13 at 18 11 28](https://f.cloud.github.com/assets/872004/1531898/bf364052-4c6e-11e3-9dcb-64e798f67bf7.png)
