### PR TITLE
always-semicolon: Support for scss and less

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ CLI mode:
 
 ### always-semicolon
 
+Whether to add a semicolon after the last value/mixin.
+
 Available value: `{Boolean}` `true`
 
 Example: `{ "always-semicolon": true }`
@@ -206,6 +208,45 @@ a { color: red }
 
 /* after */
 a { color: red; }
+```
+
+Example: `{ "always-semicolon": true }` (scss file):
+
+```scss
+// before
+div {
+    color: tomato;
+    @include nani
+    }
+
+// after
+div {
+    color: tomato;
+    @include nani;
+    }
+```
+
+Note that in `*.scss` and `*.less` files semicolons are not added after `}`
+even if it's part of a value:
+
+```scss
+// before
+div {
+    color: tomato;
+    font: {
+        family: fantasy;
+        size: 16px
+        }
+    }
+
+// after
+div {
+    color: tomato;
+    font: {
+        family: fantasy;
+        size: 16px;
+        }
+    }
 ```
 
 ### block-indent

--- a/lib/options/always-semicolon.js
+++ b/lib/options/always-semicolon.js
@@ -5,6 +5,7 @@ module.exports = {
      *
      * @param {String|Boolean} value Option value
      * @returns {Object|undefined}
+     * TODO: This option accepts only boolean
      */
     setValue: function(value) {
         this._value = value === true;
@@ -20,31 +21,53 @@ module.exports = {
     process: function(nodeType, node) {
         if (nodeType === 'block') {
             for (var i = node.length; i--;) {
-                var nodeItem = node[i];
-                var type = nodeItem[0];
+                var currentNode = node[i];
+                var currentNodeType = currentNode[0];
+                var nodeWithoutSemicolon;
 
-                if (type === 'declDelim') break;
+                // Skip nodes that already have `;` at the end:
+                if (currentNodeType === 'declDelim') break;
 
-                if (type === 'declaration') {
-                    // Look for value node:
-                    var value;
-                    for (var k = nodeItem.length; k--;) {
-                        if (nodeItem[k][0] === 'value') {
-                            value = nodeItem[k];
+                // Add semicolon only after declarations and includes.
+                // If current node is include, insert semicolon right into it.
+                // If it's declaration, look for value node:
+                if (currentNodeType === 'include') {
+                    nodeWithoutSemicolon = currentNode;
+                } else if (currentNodeType === 'declaration') {
+                    for (var k = currentNode.length; k--;) {
+                        if (currentNode[k][0] === 'value') {
+                            nodeWithoutSemicolon = currentNode[k];
                             break;
                         }
                     }
-
-                    var space = [];
-                    for (var j = value.length; j--;) {
-                        if (['s', 'commentML', 'commentSL'].indexOf(value[j][0]) === -1) break;
-                        space.unshift(value.splice(j)[0]);
-                    }
-                    node.splice.apply(node, [i + 1, 0, ['declDelim']].concat(space));
-                    break;
+                } else {
+                    continue;
                 }
+
+                var space = [];
+                var isBlock = false;
+
+                // Check if there are spaces and comments at the end of the node:
+                for (var j = nodeWithoutSemicolon.length; j--;) {
+                    var lastNode = nodeWithoutSemicolon[j][0];
+                    // If the node's last child is block, do not add semicolon:
+                    // TODO: Add syntax check and run the code only for scss
+                    if (lastNode === 'block') {
+                        isBlock = true;
+                        break;
+                    } else if (['s', 'commentML', 'commentSL'].indexOf(lastNode) === -1) break;
+
+                    space.unshift(nodeWithoutSemicolon[j]);
+                }
+
+                if (isBlock) break;
+
+                // Temporarily remove last spaces and comments and insert `;`
+                // before them:
+                nodeWithoutSemicolon.splice(nodeWithoutSemicolon.length - space.length);
+                node.splice.apply(node, [i + 1, 0, ['declDelim']].concat(space));
+                break;
             }
         }
     }
-
 };

--- a/test/always-semicolon-less.js
+++ b/test/always-semicolon-less.js
@@ -1,0 +1,100 @@
+var Comb = require('../lib/csscomb');
+var assert = require('assert');
+var fs = require('fs');
+
+describe('options/always-semicolon (scss)', function() {
+    var comb;
+    var input;
+    var expected;
+
+    function readFile(path) {
+        return fs.readFileSync('test/always-semicolon-less/' + path, 'utf8');
+    }
+
+    beforeEach(function() {
+        comb = new Comb();
+        comb.configure({ 'always-semicolon': true });
+    });
+
+    it('Should not add semicolon to condition (single-line style)', function() {
+        input = readFile('condition.less');
+
+        assert.equal(comb.processString(input, 'less'), input);
+    });
+
+    it('Should not add semicolon to condition (multi-line style)', function() {
+        input = readFile('condition-multiline.less');
+
+        assert.equal(comb.processString(input, 'less'), input);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 1 (single-line style)', function() {
+        input = readFile('include-1.less');
+        expected = readFile('include-1.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 1 (multi-line style)', function() {
+        input = readFile('include-1-multiline.less');
+        expected = readFile('include-1-multiline.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 2 (single-line style)', function() {
+        input = readFile('include-2.less');
+        expected = readFile('include-2.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 2 (multi-line style)', function() {
+        input = readFile('include-2-multiline.less');
+        expected = readFile('include-2-multiline.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 3 (single-line style)', function() {
+        input = readFile('include-3.less');
+        expected = readFile('include-3.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 3 (multi-line style)', function() {
+        input = readFile('include-3-multiline.less');
+        expected = readFile('include-3-multiline.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 4 (single-line style)', function() {
+        input = readFile('include-4.less');
+        expected = readFile('include-4.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 4 (multi-line style)', function() {
+        input = readFile('include-4-multiline.less');
+        expected = readFile('include-4-multiline.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 5 (single-line style)', function() {
+        input = readFile('include-5.less');
+        expected = readFile('include-5.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 5 (multi-line style)', function() {
+        input = readFile('include-5-multiline.less');
+        expected = readFile('include-5-multiline.expected.less');
+
+        assert.equal(comb.processString(input, 'less'), expected);
+    });
+});

--- a/test/always-semicolon-less/condition-multiline.less
+++ b/test/always-semicolon-less/condition-multiline.less
@@ -1,0 +1,6 @@
+div {
+    @color: tomato;
+    when (@color = tomato) {
+        top: 0;
+        }
+    }

--- a/test/always-semicolon-less/condition.less
+++ b/test/always-semicolon-less/condition.less
@@ -1,0 +1,1 @@
+div { @color: tomato; when (@color = tomato) { top: 0; } }

--- a/test/always-semicolon-less/include-1-multiline.expected.less
+++ b/test/always-semicolon-less/include-1-multiline.expected.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    .nani;
+    }

--- a/test/always-semicolon-less/include-1-multiline.less
+++ b/test/always-semicolon-less/include-1-multiline.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    .nani
+    }

--- a/test/always-semicolon-less/include-1.expected.less
+++ b/test/always-semicolon-less/include-1.expected.less
@@ -1,0 +1,1 @@
+div { color: tomato; .nani; }

--- a/test/always-semicolon-less/include-1.less
+++ b/test/always-semicolon-less/include-1.less
@@ -1,0 +1,1 @@
+div { color: tomato; .nani }

--- a/test/always-semicolon-less/include-2-multiline.expected.less
+++ b/test/always-semicolon-less/include-2-multiline.expected.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    .nani(2px);
+    }

--- a/test/always-semicolon-less/include-2-multiline.less
+++ b/test/always-semicolon-less/include-2-multiline.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    .nani(2px)
+    }

--- a/test/always-semicolon-less/include-2.expected.less
+++ b/test/always-semicolon-less/include-2.expected.less
@@ -1,0 +1,1 @@
+div { color: tomato; .nani(2px); }

--- a/test/always-semicolon-less/include-2.less
+++ b/test/always-semicolon-less/include-2.less
@@ -1,0 +1,1 @@
+div { color: tomato; .nani(2px) }

--- a/test/always-semicolon-less/include-3-multiline.expected.less
+++ b/test/always-semicolon-less/include-3-multiline.expected.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    .nani(2px) !important;
+    }

--- a/test/always-semicolon-less/include-3-multiline.less
+++ b/test/always-semicolon-less/include-3-multiline.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    .nani(2px) !important
+    }

--- a/test/always-semicolon-less/include-3.expected.less
+++ b/test/always-semicolon-less/include-3.expected.less
@@ -1,0 +1,1 @@
+div { color: tomato; .nani(2px) !important; }

--- a/test/always-semicolon-less/include-3.less
+++ b/test/always-semicolon-less/include-3.less
@@ -1,0 +1,1 @@
+div { color: tomato; .nani(2px) !important }

--- a/test/always-semicolon-less/include-4-multiline.expected.less
+++ b/test/always-semicolon-less/include-4-multiline.expected.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    #bundle > .button;
+    }

--- a/test/always-semicolon-less/include-4-multiline.less
+++ b/test/always-semicolon-less/include-4-multiline.less
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    #bundle > .button
+    }

--- a/test/always-semicolon-less/include-4.expected.less
+++ b/test/always-semicolon-less/include-4.expected.less
@@ -1,0 +1,1 @@
+div { color: tomato; #bundle > .button; }

--- a/test/always-semicolon-less/include-4.less
+++ b/test/always-semicolon-less/include-4.less
@@ -1,0 +1,1 @@
+div { color: tomato; #bundle > .button }

--- a/test/always-semicolon-less/include-5-multiline.expected.less
+++ b/test/always-semicolon-less/include-5-multiline.expected.less
@@ -1,0 +1,4 @@
+div {
+    @color: tomato;
+    #bundle > .button (@color);
+    }

--- a/test/always-semicolon-less/include-5-multiline.less
+++ b/test/always-semicolon-less/include-5-multiline.less
@@ -1,0 +1,4 @@
+div {
+    @color: tomato;
+    #bundle > .button (@color)
+    }

--- a/test/always-semicolon-less/include-5.expected.less
+++ b/test/always-semicolon-less/include-5.expected.less
@@ -1,0 +1,1 @@
+div { @color: tomato; #bundle > .button (@color); }

--- a/test/always-semicolon-less/include-5.less
+++ b/test/always-semicolon-less/include-5.less
@@ -1,0 +1,1 @@
+div { @color: tomato; #bundle > .button (@color) }

--- a/test/always-semicolon-scss.js
+++ b/test/always-semicolon-scss.js
@@ -1,0 +1,108 @@
+var Comb = require('../lib/csscomb');
+var assert = require('assert');
+var fs = require('fs');
+
+describe('options/always-semicolon (scss)', function() {
+    var comb;
+    var input;
+    var expected;
+
+    function readFile(path) {
+        return fs.readFileSync('test/always-semicolon-scss/' + path, 'utf8');
+    }
+
+    beforeEach(function() {
+        comb = new Comb();
+        comb.configure({ 'always-semicolon': true });
+    });
+
+    it('Should not add semicolon if last value is block (singl-line style)', function() {
+        input = readFile('block-value.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should not add semicolon if last value is block (multi-line style)', function() {
+        input = readFile('block-value-multiline.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 1 (single-line style)', function() {
+        input = readFile('include-1.scss');
+        expected = readFile('include-1.expected.scss');
+
+        assert.equal(comb.processString(input, 'scss'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 1 (multi-line style)', function() {
+        input = readFile('include-1-multiline.scss');
+        expected = readFile('include-1-multiline.expected.scss');
+
+        assert.equal(comb.processString(input, 'scss'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 2 (single-line style)', function() {
+        input = readFile('include-2.scss');
+        expected = readFile('include-2.expected.scss');
+
+        assert.equal(comb.processString(input, 'scss'), expected);
+    });
+
+    it('Should add semicolon to last included mixin if missing. Test 2 (multi-line style)', function() {
+        input = readFile('include-2-multiline.scss');
+        expected = readFile('include-2-multiline.expected.scss');
+
+        assert.equal(comb.processString(input, 'scss'), expected);
+    });
+
+    it('Should not add semicolon to last included mixin if there is a block (single-line style)', function() {
+        input = readFile('block-include.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should not add semicolon to last included mixin if there is a block (multi-line style)', function() {
+        input = readFile('block-include-multiline.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should add semicolon to last extend if missing (single-line style)', function() {
+        input = readFile('extend.scss');
+        expected = readFile('extend.expected.scss');
+
+        assert.equal(comb.processString(input, 'scss'), expected);
+    });
+
+    it('Should add semicolon to last extend if missing (multi-line style)', function() {
+        input = readFile('extend-multiline.scss');
+        expected = readFile('extend-multiline.expected.scss');
+
+        assert.equal(comb.processString(input, 'scss'), expected);
+    });
+
+    it('Should not add semicolon to condition (single-line style)', function() {
+        input = readFile('condition.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should not add semicolon to condition (multi-line style)', function() {
+        input = readFile('condition-multiline.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should not add semicolon to loop (single-line style)', function() {
+        input = readFile('loop.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+
+    it('Should not add semicolon to loop (multi-line style)', function() {
+        input = readFile('loop-multiline.scss');
+
+        assert.equal(comb.processString(input, 'scss'), input);
+    });
+});

--- a/test/always-semicolon-scss/block-include-multiline.scss
+++ b/test/always-semicolon-scss/block-include-multiline.scss
@@ -1,0 +1,7 @@
+div {
+    color: tomato;
+    @include nani {
+        top: 0;
+        content: '';
+        }
+    }

--- a/test/always-semicolon-scss/block-include.scss
+++ b/test/always-semicolon-scss/block-include.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @include nani { top: 0; content: ''; } }

--- a/test/always-semicolon-scss/block-value-multiline.scss
+++ b/test/always-semicolon-scss/block-value-multiline.scss
@@ -1,0 +1,7 @@
+div {
+    color: tomato;
+    font: {
+        family: fantasy;
+        size: 16px;
+        }
+    }

--- a/test/always-semicolon-scss/block-value.scss
+++ b/test/always-semicolon-scss/block-value.scss
@@ -1,0 +1,1 @@
+div { color: tomato; font: { family: fantasy; size: 16px; } }

--- a/test/always-semicolon-scss/condition-multiline.scss
+++ b/test/always-semicolon-scss/condition-multiline.scss
@@ -1,0 +1,6 @@
+div {
+    $color: tomato;
+    @if $color == tomato {
+        top: 0;
+        }
+    }

--- a/test/always-semicolon-scss/condition.scss
+++ b/test/always-semicolon-scss/condition.scss
@@ -1,0 +1,1 @@
+div { $color: tomato; @if $color == tomato { top: 0; } }

--- a/test/always-semicolon-scss/extend-multiline.expected.scss
+++ b/test/always-semicolon-scss/extend-multiline.expected.scss
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    @extend .nani;
+    }

--- a/test/always-semicolon-scss/extend-multiline.scss
+++ b/test/always-semicolon-scss/extend-multiline.scss
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    @extend .nani
+    }

--- a/test/always-semicolon-scss/extend.expected.scss
+++ b/test/always-semicolon-scss/extend.expected.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @extend .nani; }

--- a/test/always-semicolon-scss/extend.scss
+++ b/test/always-semicolon-scss/extend.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @extend .nani }

--- a/test/always-semicolon-scss/include-1-multiline.expected.scss
+++ b/test/always-semicolon-scss/include-1-multiline.expected.scss
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    @include nani;
+    }

--- a/test/always-semicolon-scss/include-1-multiline.scss
+++ b/test/always-semicolon-scss/include-1-multiline.scss
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    @include nani
+    }

--- a/test/always-semicolon-scss/include-1.expected.scss
+++ b/test/always-semicolon-scss/include-1.expected.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @include nani; }

--- a/test/always-semicolon-scss/include-1.scss
+++ b/test/always-semicolon-scss/include-1.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @include nani }

--- a/test/always-semicolon-scss/include-2-multiline.expected.scss
+++ b/test/always-semicolon-scss/include-2-multiline.expected.scss
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    @include nani(10);
+    }

--- a/test/always-semicolon-scss/include-2-multiline.scss
+++ b/test/always-semicolon-scss/include-2-multiline.scss
@@ -1,0 +1,4 @@
+div {
+    color: tomato;
+    @include nani(10)
+    }

--- a/test/always-semicolon-scss/include-2.expected.scss
+++ b/test/always-semicolon-scss/include-2.expected.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @include nani(10); }

--- a/test/always-semicolon-scss/include-2.scss
+++ b/test/always-semicolon-scss/include-2.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @include nani(10) }

--- a/test/always-semicolon-scss/loop-multiline.scss
+++ b/test/always-semicolon-scss/loop-multiline.scss
@@ -1,0 +1,6 @@
+div {
+    color: tomato;
+    @while 1 > 2 {
+        top: 0;
+        }
+    }

--- a/test/always-semicolon-scss/loop.scss
+++ b/test/always-semicolon-scss/loop.scss
@@ -1,0 +1,1 @@
+div { color: tomato; @while 1 > 2 { top: 0; } }


### PR DESCRIPTION
- Add semicolons after includes
- Do not add semicolons after `}` even if it's part of a value (see Readme)

Readme is updated.
