### PR TITLE
CLI: Search for a config file recursively (#68, 106)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@
  * ./node_modules/.bin/csscomb [options] file1 [dir1 [fileN [dirN]]]
  */
 var fs = require('fs');
+var path = require('path');
 var program = require('commander');
 var vow = require('vow');
 var Comb = require('./csscomb');
@@ -23,7 +24,34 @@ if (!program.args.length) {
     program.help();
 }
 
-var configPath = program.config || (process.cwd() + '/config/csscomb.json');
+/**
+ * Look for a config file: recursively from current (process) directory
+ * up to $HOME dir
+ * @param {String} configPath
+ * @returns {String}
+ */
+function getConfigPath(configPath) {
+    var HOME = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+    // Since `process.cwd()` can be absolutely anything, build default path
+    // relative to current directory:
+    var defaultConfigPath = __dirname + '/../config/csscomb.json';
+
+    configPath = configPath || process.cwd() + '/.csscomb.json';
+
+    // If we've finally found a config, return its path:
+    if (fs.existsSync(configPath)) return configPath;
+
+    // If we are in HOME dir already and yet no config file, return a default
+    // one from our package:
+    if (path.dirname(configPath) === HOME) return defaultConfigPath;
+
+    // If there is no config in this directory, go one level up and look for
+    // a config there:
+    configPath = path.dirname(path.dirname(configPath)) + '/.csscomb.json';
+    return getConfigPath(configPath);
+}
+
+var configPath = program.config || getConfigPath();
 var comb = new Comb();
 
 if (program.detect) {


### PR DESCRIPTION
Issues #68 and #106.

Check if there is a `.csscomb.json` file in process directory.
If not, go one level up and search there.
Stop in HOME dir.
If no user's config found, take a default one from our package: `config/csscomb.json`.

Any ideas about writing tests are welcome.

![tumblr_mvwp4uoyc91slo91to1_400](https://f.cloud.github.com/assets/872004/1592350/d329a09e-52b9-11e3-842c-6509c6d22495.gif)
