### PR TITLE
Add getConfig() method (#103)

### DIFF
--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -38,6 +38,27 @@ var Comb = function() {
 Comb.prototype = {
 
     /**
+     * Get one of configuration files from `config` directory
+     * @param {String} name Config's name: 'csscomb', 'zen' or 'yandex'
+     * @returns {Object} Configuration object
+     */
+    getConfig: function(name) {
+        name = name || 'csscomb';
+
+        if (typeof name !== 'string') {
+            throw new Error('Config name should be a string');
+        }
+
+        if (['csscomb', 'zen', 'yandex'].indexOf(name) < 0) {
+            var message = name + ' is not a valid config name. Try one of ' +
+                'the following: \'csscomb\', \'zen\' or \'yandex\'.';
+            throw new Error(message);
+        }
+
+        return require('../config/' + name + '.json');
+    },
+
+    /**
      * Loads configuration from JSON.
      * Activates and configures required options.
      *

--- a/test/get-config.js
+++ b/test/get-config.js
@@ -1,0 +1,54 @@
+var Comb = require('../lib/csscomb');
+var assert = require('assert');
+
+describe('csscomb methods', function() {
+    var comb = new Comb();
+
+    it('getConfig()', function() {
+        var config = require('../config/csscomb.json');
+
+        assert.equal(comb.getConfig(), config);
+    });
+
+    it('getConfig(number)', function() {
+        assert.throws(function() {
+            comb.getConfig(16);
+        });
+    });
+
+    it('getConfig(boolean)', function() {
+        assert.throws(function() {
+            comb.getConfig(true);
+        });
+    });
+
+    it('getConfig(empty string)', function() {
+        var config = require('../config/csscomb.json');
+
+        assert.equal(comb.getConfig(''), config);
+    });
+
+    it('getConfig(invalid string)', function() {
+        assert.throws(function() {
+            comb.getConfig('nani');
+        });
+    });
+
+    it('getConfig(csscomb)', function() {
+        var config = require('../config/csscomb.json');
+
+        assert.equal(comb.getConfig('csscomb'), config);
+    });
+
+    it('getConfig(zen)', function() {
+        var config = require('../config/zen.json');
+
+        assert.equal(comb.getConfig('zen'), config);
+    });
+
+    it('getConfig(yandex)', function() {
+        var config = require('../config/yandex.json');
+
+        assert.equal(comb.getConfig('yandex'), config);
+    });
+});


### PR DESCRIPTION
Issue #103.

Examples:

``` js
var Comb = require('csscomb');
var c = new Comb();

// Pass no arguments:
c.getConfig(); // default `csscomb.json` object is returned

// Pass a valid name:
c.getConfig('csscomb'); // `csscomb.json` object is returned
c.getConfig('zen'); // `zen.json` object is returned
c.getConfig('yandex'); // `yandex.json` object is returned

// Pass something invalid:
c.getConfig('nani'); // throw Error
c.getConfig(16); // throw Error
```

![tumblr_mhxs03dwvw1s4nb6vo1_250](https://f.cloud.github.com/assets/872004/1592404/e0574fcc-52ba-11e3-975f-8ddb440759b6.gif)
