### PR TITLE
Update vendor-prefix-align.js

### DIFF
--- a/lib/options/vendor-prefix-align.js
+++ b/lib/options/vendor-prefix-align.js
@@ -84,7 +84,7 @@ module.exports = {
      */
     _getValName: function(node) {
         // TODO: Check that `node[3]` is the node we need
-        if (node[0] !== 'declaration' || !node[3] || !node[3])
+        if (node[0] !== 'declaration' || !node[3] || !node[3][2])
             return;
         if (node[3][2][0] === 'ident')
             return node[3][2][1];


### PR DESCRIPTION
Fix for a check if node exists in `_getValName`.
It got broken in cd5306.

![tumblr_muqetmv38t1riml7wo1_400](https://f.cloud.github.com/assets/872004/1653779/9b78b118-5b3c-11e3-923e-02743692254a.gif)
