### PR TITLE
Pass config to `new Comb()` and make it chainable (#102)

### DIFF
--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -42,6 +42,9 @@ var Comb = function(config) {
     }
 
     if (typeof config === 'object') this.configure(config);
+
+    // Return Comb's object to make creating new instance chainable:
+    return this;
 };
 
 Comb.prototype = {
@@ -95,6 +98,9 @@ Comb.prototype = {
         this.changed = 0;
         this._verbose = config.verbose;
         this._lint = config.lint;
+
+        // Return Comb's object to make the method chainable:
+        return this;
     },
 
     /**

--- a/test/configure.js
+++ b/test/configure.js
@@ -29,4 +29,20 @@ describe('csscomb methods', function() {
 
         assert.equal(expected, output);
     });
+
+    it('new Comb() should be chainable', function() {
+        input = 'a { color: tomato; top: 0; }';
+        expected = 'a {top: 0;  color: tomato; }';
+        output = new Comb('zen').processString(input);
+
+        assert.equal(expected, output);
+    });
+
+    it('configure() should be chainable', function() {
+        input = 'a { color: tomato }';
+        expected = 'a { color: tomato; }';
+        output = new Comb().configure({ 'always-semicolon': true }).processString(input);
+
+        assert.equal(expected, output);
+    });
 });


### PR DESCRIPTION
Issue #102

You can now create new Comb instance and configure it at the same time.
To use one of predefined configs, pass its name:

``` js
var comb = new Comb('zen'); // or `csscomb`, or `yandex`
```

To use custom config, pass its object:

``` js
 var comb = new Comb({ 'always-semicolon': true });
```

Also `new Comb()` and `configure()` are chainable now.
It means you can do things like:

``` js
// Init, configure and process:
var combed = new Comb('csscomb').processString('a { color: tomato }');

// Comb a file with one line of code:
new Comb().configure({ 'always-semicolon': true }).processFile('panda.less');
```
