### PR TITLE
Sort order: Make array of strings an acceptable value (#127)

### DIFF
--- a/lib/options/sort-order.js
+++ b/lib/options/sort-order.js
@@ -10,11 +10,18 @@ module.exports = {
         if (!value) return;
 
         this._order = {};
-        value.forEach(function(group, groupIndex) {
-            group.forEach(function(prop, propIndex) {
-                this._order[prop] = { group: groupIndex, prop: propIndex };
+
+        if (typeof value[0] === 'string') {
+            value.forEach(function(prop, propIndex) {
+                this._order[prop] = { group: 0, prop: propIndex };
             }, this);
-        }, this);
+        } else {
+            value.forEach(function(group, groupIndex) {
+                group.forEach(function(prop, propIndex) {
+                    this._order[prop] = { group: groupIndex, prop: propIndex };
+                }, this);
+            }, this);
+        }
 
         return this;
     },

--- a/test/sort-order.js
+++ b/test/sort-order.js
@@ -13,6 +13,16 @@ describe('options/sort-order', function() {
         comb = new Comb();
     });
 
+    it('Should be in expected order in case properties are not grouped', function() {
+        var config = { 'sort-order': ['position', 'z-index'] };
+
+        var input = readFile('single-group.css');
+        var expected = readFile('single-group.expected.css');
+
+        comb.configure(config);
+        assert.equal(comb.processString(input), expected);
+    });
+
     it('Should be in expected order in case of 1 group', function() {
         var config = { 'sort-order': [
             ['position', 'z-index']


### PR DESCRIPTION
Issue #127

In config you can now use `sort-order: [ 'top', 'color' ]` instead of `sort-order: [ [ 'top', 'color' ] ]`

![jcvtuo5](https://f.cloud.github.com/assets/872004/1755190/8d19caa6-6660-11e3-9635-48d7dccca959.gif)
