### PR TITLE
Add test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+lib-cov
 node_modules
+test/test-coverage.html
 
 .idea
 *.iml

--- a/.jscs.json
+++ b/.jscs.json
@@ -1,6 +1,7 @@
 {
     "excludeFiles": [
-        "node_modules/**"
+        "node_modules/**",
+        "lib-cov/**"
     ],
     "requireCurlyBraces": [
         "else",

--- a/README.md
+++ b/README.md
@@ -721,6 +721,14 @@ a
 
 Run `npm test` for tests.
 
+To check test coverage, you need `jscoverage` tool.
+Once it is installed ([see instructions here](https://github.com/visionmedia/node-jscoverage#installation)), run:
+
+```
+npm run-script test-cov
+open ./test/test-coverage.html
+```
+
 ## Contributing
 
 Anyone and everyone is welcome to contribute. Please take a moment to

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "csscomb": "./bin/csscomb"
     },
     "scripts": {
-        "test": "./node_modules/.bin/jshint-groups && ./node_modules/.bin/jscs . && ./node_modules/.bin/mocha -u bdd -R dot"
+        "test": "./node_modules/.bin/jshint-groups && ./node_modules/.bin/jscs . && ./node_modules/.bin/mocha -u bdd -R dot",
+        "test-cov": "rm -rf lib-cov && jscoverage lib lib-cov && TEST_COV=true ./node_modules/.bin/mocha -R html-cov > ./test/test-coverage.html"
     }
 }

--- a/test/always-semicolon-less.js
+++ b/test/always-semicolon-less.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/always-semicolon-scss.js
+++ b/test/always-semicolon-scss.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/always-semicolon.js
+++ b/test/always-semicolon.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/always-semicolon', function() {

--- a/test/block-indent.js
+++ b/test/block-indent.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/block-indent', function() {

--- a/test/colon-space.js
+++ b/test/colon-space.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/colon-space', function() {

--- a/test/color-case.js
+++ b/test/color-case.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/color-case', function() {

--- a/test/color-shorthand.js
+++ b/test/color-shorthand.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/color-shorthand', function() {

--- a/test/combinator-space.js
+++ b/test/combinator-space.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/combinator-space', function() {

--- a/test/configure.js
+++ b/test/configure.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('csscomb methods', function() {

--- a/test/csscomb.js
+++ b/test/csscomb.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('csscomb methods', function() {

--- a/test/element-case.js
+++ b/test/element-case.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/element-case', function() {

--- a/test/eof-newline.js
+++ b/test/eof-newline.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/eof-newline', function() {

--- a/test/get-config.js
+++ b/test/get-config.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('csscomb methods', function() {

--- a/test/integral.js
+++ b/test/integral.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var vow = require('vow');
 var vfs = require('vow-fs');

--- a/test/leading-zero.js
+++ b/test/leading-zero.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/leading-zero', function() {

--- a/test/less.js
+++ b/test/less.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/quotes.js
+++ b/test/quotes.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/quotes', function() {

--- a/test/remove-empty-rulesets.js
+++ b/test/remove-empty-rulesets.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/remove-empty-rulesets', function() {

--- a/test/rule-indent.js
+++ b/test/rule-indent.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/rule-indent', function() {

--- a/test/scss.js
+++ b/test/scss.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/sort-order-less.js
+++ b/test/sort-order-less.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/sort-order-scss.js
+++ b/test/sort-order-scss.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/sort-order.js
+++ b/test/sort-order.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/stick-brace.js
+++ b/test/stick-brace.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/stick-brace', function() {

--- a/test/strip-spaces.js
+++ b/test/strip-spaces.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/strip-spaces', function() {

--- a/test/unitless-zero.js
+++ b/test/unitless-zero.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var assert = require('assert');
 
 describe('options/unitless-zero', function() {

--- a/test/vendor-prefix-align.js
+++ b/test/vendor-prefix-align.js
@@ -1,4 +1,4 @@
-var Comb = require('../lib/csscomb');
+var Comb = process.env.TEST_COV ? require('../lib-cov/csscomb') : require('../lib/csscomb');
 var fs = require('fs');
 var assert = require('assert');
 


### PR DESCRIPTION
Use `jscoverage` tool and Mocha to built test coverage report.

Install jscoverage: https://github.com/visionmedia/node-jscoverage#installation
Run:

```
npm run-script test-cov
open ./test/test-coverage.html
```

Get something like this:

![screen 20shot 202013-12-20 20at 2017 47 11](https://f.cloud.github.com/assets/872004/1790683/58a2be2a-697d-11e3-8763-bc8897601ca4.png)
