### PR TITLE
Move documentation to `doc` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ CSScomb is a coding style formatter for CSS.
 You can easily write your own [configuration](doc/configuration.md) to make
 your style sheets beautiful and consistent.
 
-The main feature is [sorting properties](doc/options.md#sort-order) in a specific order.    
+The main feature is [sorting properties](doc/options.md#sort-order) in a specific order.
 It was inspired by [@miripiruni](https://github.com/miripiruni)'s
-[PHP-based tool](https://github.com/csscomb/csscomb) of the same name.    
+[PHP-based tool](https://github.com/csscomb/csscomb) of the same name.
 This is the new JavaScript version, based on the powerful CSS parser
 [Gonzales PE](https://github.com/tonyganch/gonzales-pe).
 
@@ -64,7 +64,7 @@ comb.processPath('assets/css');
 
 ## 4. Contribute
 
-Anyone and everyone is welcome to contribute.    
+Anyone and everyone is welcome to contribute.
 Please take a moment to review the [guidelines for contributing](CONTRIBUTE.md).
 
 ## Authors

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-You must configure CSScomb before use.    
+You must configure CSScomb before use.
 There are a number of ways how you can do it.
 
 ## Use one of predefined configs
@@ -14,7 +14,7 @@ included in this project you can use right away:
 - `yandex`
 
 In CLI, `csscomb` is a default config file that is used unless you provide your
-own.    
+own.
 In Node.js, you can pass config's name to constructor:
 
 ```js
@@ -23,12 +23,12 @@ var comb = new Comb('yandex');
 ```
 
 Feel free to use predefined configs as examples: copy one of them and modify to
-your taste.    
+your taste.
 Just remember to save the file as `.csscomb.json` in project's root.
 
 ## Create custom config
 
-You can easily write your own configuration.    
+You can easily write your own configuration.
 The only requirement is that config is valid JSON in order to work correctly.
 
 Here is an example:
@@ -60,14 +60,14 @@ Take a look at [available options](options.md) and choose those you need.
 
 ### Where to put config
 
-CSScomb will look for a file named `.csscomb.json`.    
-The best way is to put the file in your project's root.    
+CSScomb will look for a file named `.csscomb.json`.
+The best way is to put the file in your project's root.
 However, if you want to use one config for several projects, it's fine to put
-the file inside a parent folder.    
+the file inside a parent folder.
 CSScomb will look for a config file recursively up untill it reaches your
 `HOME` directory.
 
-Remember that you can always set custom path.    
+Remember that you can always set custom path.
 In CLI:
 ```bash
 csscomb -c path/to/config assets/css
@@ -83,7 +83,7 @@ var comb = new Comb(config);
 ## Generate config from a template
 
 Instead of configuring all the options one by one, you can use a template file:
-CSScomb will detect the coding style and use it as a config.    
+CSScomb will detect the coding style and use it as a config.
 All existing properties except `sort-order` can be configured this way:
 
 ```bash
@@ -141,4 +141,3 @@ This config will:
 1. then use `"leading-zero":  false` instead of anything detected,
 1. then use `"vendor-prefix-align": true` even if there were no prefixed
 properties or values inside the `example.css`.
-

--- a/doc/options.md
+++ b/doc/options.md
@@ -537,4 +537,3 @@ csscomb ./test
 1 file fixed
 96 ms spent
 ```
-

--- a/doc/usage-cli.md
+++ b/doc/usage-cli.md
@@ -43,7 +43,7 @@ csscomb -h
 
 If you want to use custom config instead of predefined `csscomb.json` just
 put a file named `.csscomb.json` to project's root (see [configuration
-docs](configuration.md#where-to-put-config) for more information).    
+docs](configuration.md#where-to-put-config) for more information).
 However, if for some reason you would like to use custom path, do it this way:
 
 ```bash
@@ -64,7 +64,7 @@ more information.
 ### lint
 
 CSScomb can be used as a linter, i.e. telling you what should be changed instead
-of modifying anything.    
+of modifying anything.
 This option should be combined with `--verbose`:
 
 ```bash

--- a/doc/usage-node.md
+++ b/doc/usage-node.md
@@ -205,4 +205,3 @@ var css = 'a {top: 0; left: 0}';
 var config = comb.detectInString(css);
 comb.configure(config);
 ```
-


### PR DESCRIPTION
Issues #97, #134

Documentation is updated, separated into 4 files and moved to `doc` directory.
`CSSComb` and `csscomb` are all renamed to `CSScomb`.

Note that links to `config` directory are absolute.
That is done intentionally because the same files will be used on our web site.

Try it live: https://github.com/csscomb/csscomb.js/tree/tg/134-docs

![tumblr_me8rcipt3r1rpxgkao1_500](https://f.cloud.github.com/assets/872004/1796189/04e3a992-6a5a-11e3-84e2-202a89e384c7.gif)
