### PR TITLE
Stop searching config if we reach root directory

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,9 +34,9 @@ function getConfigPath(configPath) {
     var HOME = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
     // Since `process.cwd()` can be absolutely anything, build default path
     // relative to current directory:
-    var defaultConfigPath = __dirname + '/../config/csscomb.json';
+    var defaultConfigPath = path.join(__dirname, '../config/csscomb.json');
 
-    configPath = configPath || process.cwd() + '/.csscomb.json';
+    configPath = configPath || path.join(process.cwd(), '.csscomb.json');
 
     // If we've finally found a config, return its path:
     if (fs.existsSync(configPath)) return configPath;
@@ -53,7 +53,7 @@ function getConfigPath(configPath) {
 
     // If there is no config in this directory, go one level up and look for
     // a config there:
-    configPath = parentDirname + '/.csscomb.json';
+    configPath = path.join(parentDirname, '.csscomb.json');
     return getConfigPath(configPath);
 }
 


### PR DESCRIPTION
See csscomb/grunt-csscomb#19

If project is located not under `HOME` (e.g. `/var/test`) and we try to comb some files, we get an error:

```
$ cd /var/test && csscomb foo.css

path.js:299
    return splitPathRe.exec(filename).slice(1);
                       ^
RangeError: Maximum call stack size exceeded
```

The problem is in `getConfigPath` function which stops searching config only after reaching `HOME`.
And as we can't get there from `/var/test`, we get into infinite loop instead.
This can be solved by comparing to root as well.
And since there appears to be no good way to get root path in Windows, assume that if current dir has no parent dir, we're in root.

![post-18511-i-m-outta-here-mlkshk-91ab](https://f.cloud.github.com/assets/872004/1817144/c7449f78-6f78-11e3-993c-b6478062b8bb.gif)
