### PR TITLE
[WIP] Added `context` argument to the `processString` method

### DIFF
--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -195,12 +195,13 @@ Comb.prototype = {
      * @param {String} [syntax] Syntax name (e.g. `scss`)
      * @param {String} [filename]
      */
-    processString: function(text, syntax, filename) {
+    processString: function(text, syntax, filename, context) {
         if (!text) return text;
         var tree;
         var string = JSON.stringify;
+        context = context || 'stylesheet';
         try {
-            tree = gonzales.cssToAST({ syntax: syntax, css: text });
+            tree = gonzales.cssToAST({ syntax: syntax, css: text, rule: context });
         } catch (e) {
             throw new Error('Parsing error at ' + filename + ': ' + e.message);
         }

--- a/test/core/partial-context.js
+++ b/test/core/partial-context.js
@@ -1,0 +1,36 @@
+var Comb = process.env.TEST_COV ? require('../../lib-cov/csscomb') : require('../../lib/csscomb');
+var assert = require('assert');
+
+describe('context of processString', function() {
+    var comb;
+    var input;
+    var output;
+    var expected;
+
+    it('No `context` argument should use the whole stylesheet as context', function() {
+        comb = new Comb('zen');
+        input = 'a { color: tomato; top: 0; }';
+        expected = 'a {top: 0;  color: tomato; }';
+        output = comb.processString(input);
+
+        assert.equal(expected, output);
+    });
+
+    it('`context` argument set to `declaration` should process the content of the passed declaration', function() {
+        comb = new Comb({ 'colon-space': ['', ' '], 'color-case': 'lower', 'color-shorthand': true });
+        input = 'color:#FFFFFF';
+        expected = 'color: #fff';
+        output = comb.processString(input, null, null, 'declaration');
+
+        assert.equal(expected, output);
+    });
+
+    it('`context` argument set to `block` should process the content of the passed block', function() {
+        comb = new Comb('zen');
+        input = 'color: tomato; top: 0; ';
+        expected = 'top: 0; color: tomato; ';
+        output = comb.processString(input, null, null, 'block');
+
+        assert.equal(expected, output);
+    });
+});


### PR DESCRIPTION
This is a **work in progress**, it is not complete yet, but I'm submitting this, 'cause I'm not sure on the naming stuff etc, so you could review early and suggest any changes. I'll then fix them and rebase the branch.

The point of this PR is to allow combing of the incomplete input, so we could then use CSSComb.js in more contexts, like this one — #177 (combing of the selected blocks or declarations only).

Right now it works for declarations, but fails on blocks, as parser currently don't work with them (or I'm doing something wrong there).
