### PR TITLE
New option: space-after-colon (#92)

### DIFF
--- a/config/csscomb.json
+++ b/config/csscomb.json
@@ -12,6 +12,7 @@
     "leading-zero": false,
     "quotes": "single",
     "remove-empty-rulesets": true,
+    "space-after-colon": " ",
     "strip-spaces": true,
     "unitless-zero": true,
     "vendor-prefix-align": true,

--- a/doc/options.md
+++ b/doc/options.md
@@ -326,6 +326,47 @@ p {
 }
 ```
 
+## space-after-colon
+
+Set space after `:` in declarations.
+
+Acceptable values:
+
+* `{Number}` — number of whitespaces;
+* `{String}` — string with whitespaces, tabs or line breaks.
+
+Example: `{ 'space-after-colon': '' }`
+
+```scss
+// Before:
+a {
+    top: 0;
+    color: tomato;
+}
+
+// After:
+a {
+    top:0;
+    color:tomato;
+}
+```
+
+Example: `{ 'space-after-colon': 1 }`
+
+```scss
+// Before:
+a {
+    top:0;
+    color:tomato;
+}
+
+// After:
+a {
+    top: 0;
+    color: tomato;
+}
+```
+
 ## strip-spaces
 
 Whether to trim trailing spaces.

--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -15,6 +15,7 @@ var OPTIONS = [
     'quotes',
     'strip-spaces',
     'eof-newline',
+    'space-after-colon',
     'sort-order',
     'block-indent',
     'unitless-zero',

--- a/lib/options/space-after-colon.js
+++ b/lib/options/space-after-colon.js
@@ -1,0 +1,41 @@
+module.exports = {
+    name: 'space-after-colon',
+
+    accepts: {
+        number: true,
+        string: /^[ \t\n]*$/
+    },
+
+    /**
+     * Processes tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    process: function(nodeType, node) {
+        if (nodeType !== 'value') return;
+
+        var value = this.getValue('space-after-colon');
+
+        // Remove any spaces after colon:
+        if (node[0][0] === 's') node.shift();
+        // If the value set in config is not empty, add spaces:
+        if (value !== '') node.unshift(['s', value]);
+    },
+
+    /**
+     * Detects the value of an option at the tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    detect: function(nodeType, node) {
+        if (nodeType !== 'value') return;
+
+        if (node[0][0] === 's') {
+            return node[0][1];
+        } else {
+            return '';
+        }
+    }
+};

--- a/test/options/space-after-colon.js
+++ b/test/options/space-after-colon.js
@@ -1,0 +1,68 @@
+describe('options/space-after-colon:', function() {
+    beforeEach(function() {
+        this.filename = __filename;
+    });
+
+    it('Array value => should not change anything', function() {
+        this.comb.configure({ 'space-after-colon': ['', ' '] });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Invalid string value => should not change anything', function() {
+        this.comb.configure({ 'space-after-colon': '  nani  ' });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Float number value => should not change anything', function() {
+        this.comb.configure({ 'space-after-colon': 3.5 });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Integer value => should set proper space after colon', function() {
+        this.comb.configure({ 'space-after-colon': 0 });
+        this.shouldBeEqual('test.css', 'test.expected.css');
+    });
+
+    it('Valid string value (spaces only)=> should set proper space after colon', function() {
+        this.comb.configure({ 'space-after-colon': '  ' });
+        this.shouldBeEqual('test.css', 'test-2.expected.css');
+    });
+
+    it('Valid string value (spacesand newlines)=> should set proper space after colon', function() {
+        this.comb.configure({ 'space-after-colon': '\n    ' });
+        this.shouldBeEqual('test.css', 'test-3.expected.css');
+    });
+
+    it('Should detect no whitespaces', function() {
+        this.shouldDetect(
+            ['space-after-colon'],
+            'a { color:red }',
+            { 'space-after-colon': '' }
+        );
+    });
+
+    it('Should detect space from two variants', function() {
+        this.shouldDetect(
+            ['space-after-colon'],
+            'a { color: red; color :red }',
+            { 'space-after-colon': ' ' }
+        );
+    });
+
+    it('Should detect no whitespaces along three variants', function() {
+        this.shouldDetect(
+            ['space-after-colon'],
+            'a { color: red; background :red } b { width:10px }',
+            { 'space-after-colon': '' }
+        );
+    });
+
+    it('Should detect space', function() {
+        this.shouldDetect(
+            ['space-after-colon'],
+            'a { color : red; background :red } b { width: 10px }',
+            { 'space-after-colon': ' ' }
+        );
+    });
+});
+

--- a/test/options/space-after-colon/test-2.expected.css
+++ b/test/options/space-after-colon/test-2.expected.css
@@ -1,0 +1,5 @@
+a { color:  red }
+a{color:  red}
+a {color :  red}
+a {color :  /* foo */ red }
+a {color /* bar */ :  red }

--- a/test/options/space-after-colon/test-3.expected.css
+++ b/test/options/space-after-colon/test-3.expected.css
@@ -1,0 +1,10 @@
+a { color:
+    red }
+a{color:
+    red}
+a {color :
+    red}
+a {color :
+    /* foo */ red }
+a {color /* bar */ :
+    red }

--- a/test/options/space-after-colon/test.css
+++ b/test/options/space-after-colon/test.css
@@ -1,0 +1,5 @@
+a { color: red }
+a{color:red}
+a {color : red}
+a {color : /* foo */ red }
+a {color /* bar */ : red }

--- a/test/options/space-after-colon/test.expected.css
+++ b/test/options/space-after-colon/test.expected.css
@@ -1,0 +1,5 @@
+a { color:red }
+a{color:red}
+a {color :red}
+a {color :/* foo */ red }
+a {color /* bar */ :red }


### PR DESCRIPTION
Set space after `:` in declarations.
See #92.

Example: `{ 'space-after-colon': '' }`

``` scss
// Before:
a {
    top: 0;
    color: tomato;
}

// After:
a {
    top:0;
    color:tomato;
}
```
