### PR TITLE
New option: space-before-colon (#92)

### DIFF
--- a/config/csscomb.json
+++ b/config/csscomb.json
@@ -13,6 +13,7 @@
     "quotes": "single",
     "remove-empty-rulesets": true,
     "space-after-colon": " ",
+    "space-before-colon": "",
     "strip-spaces": true,
     "unitless-zero": true,
     "vendor-prefix-align": true,

--- a/doc/options.md
+++ b/doc/options.md
@@ -367,6 +367,47 @@ a {
 }
 ```
 
+## space-before-colon
+
+Set space before `:` in declarations.
+
+Acceptable values:
+
+* `{Number}` — number of whitespaces;
+* `{String}` — string with whitespaces, tabs or line breaks.
+
+Example: `{ 'space-before-colon': '' }`
+
+```scss
+// Before:
+a {
+    top : 0;
+    color : tomato;
+}
+
+// After:
+a {
+    top: 0;
+    color: tomato;
+}
+```
+
+Example: `{ 'space-before-colon': 1 }`
+
+```scss
+// Before:
+a {
+    top:0;
+    color:tomato;
+}
+
+// After:
+a {
+    top :0;
+    color :tomato;
+}
+```
+
 ## strip-spaces
 
 Whether to trim trailing spaces.

--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -15,6 +15,7 @@ var OPTIONS = [
     'quotes',
     'strip-spaces',
     'eof-newline',
+    'space-before-colon',
     'space-after-colon',
     'sort-order',
     'block-indent',

--- a/lib/options/space-before-colon.js
+++ b/lib/options/space-before-colon.js
@@ -1,0 +1,40 @@
+module.exports = {
+    name: 'space-before-colon',
+
+    accepts: {
+        number: true,
+        string: /^[ \t\n]*$/
+    },
+
+    /**
+     * Processes tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    process: function(nodeType, node) {
+        if (nodeType !== 'property') return;
+
+        var value = this.getValue('space-before-colon');
+
+        if (node[node.length - 1][0] === 's') node.pop();
+        if (value !== '') node.push(['s', value]);
+    },
+
+    /**
+     * Detects the value of an option at the tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    detect: function(nodeType, node) {
+        if (nodeType !== 'property') return;
+
+        var lastNode = node[node.length - 1];
+        if (lastNode[0] === 's') {
+            return lastNode[1];
+        } else {
+            return '';
+        }
+    }
+};

--- a/test/options/space-before-colon.js
+++ b/test/options/space-before-colon.js
@@ -1,0 +1,68 @@
+describe('options/space-before-colon:', function() {
+    beforeEach(function() {
+        this.filename = __filename;
+    });
+
+    it('Array value => should not change anything', function() {
+        this.comb.configure({ 'space-before-colon': ['', ' '] });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Invalid string value => should not change anything', function() {
+        this.comb.configure({ 'space-before-colon': '  nani  ' });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Float number value => should not change anything', function() {
+        this.comb.configure({ 'space-before-colon': 3.5 });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Integer value => should set proper space before colon', function() {
+        this.comb.configure({ 'space-before-colon': 0 });
+        this.shouldBeEqual('test.css', 'test.expected.css');
+    });
+
+    it('Valid string value (spaces only) => should set proper space before colon', function() {
+        this.comb.configure({ 'space-before-colon': '  ' });
+        this.shouldBeEqual('test.css', 'test-2.expected.css');
+    });
+
+    it('Valid string value (spaces and newlines) => should set proper space before colon', function() {
+        this.comb.configure({ 'space-before-colon': '\n    ' });
+        this.shouldBeEqual('test.css', 'test-3.expected.css');
+    });
+
+    it('Should detect no whitespaces', function() {
+        this.shouldDetect(
+            ['space-before-colon'],
+            'a { color:red }',
+            { 'space-before-colon': '' }
+        );
+    });
+
+    it('Should detect no space from two variants', function() {
+        this.shouldDetect(
+            ['space-before-colon'],
+            'a { color: red; color :red }',
+            { 'space-before-colon': '' }
+        );
+    });
+
+    it('Should detect no whitespaces along three variants', function() {
+        this.shouldDetect(
+            ['space-before-colon'],
+            'a { color: red; background :red } b { width:10px }',
+            { 'space-before-colon': '' }
+        );
+    });
+
+    it('Should detect space', function() {
+        this.shouldDetect(
+            ['space-before-colon'],
+            'a { color : red; background :red } b { width:10px }',
+            { 'space-before-colon': ' ' }
+        );
+    });
+});
+

--- a/test/options/space-before-colon/test-2.expected.css
+++ b/test/options/space-before-colon/test-2.expected.css
@@ -1,0 +1,5 @@
+a { color  : red }
+a{color  :red}
+a {color  : red}
+a {color  : /* foo */ red }
+a {color /* bar */  : red }

--- a/test/options/space-before-colon/test-3.expected.css
+++ b/test/options/space-before-colon/test-3.expected.css
@@ -1,0 +1,10 @@
+a { color
+    : red }
+a{color
+    :red}
+a {color
+    : red}
+a {color
+    : /* foo */ red }
+a {color /* bar */
+    : red }

--- a/test/options/space-before-colon/test.css
+++ b/test/options/space-before-colon/test.css
@@ -1,0 +1,5 @@
+a { color: red }
+a{color:red}
+a {color : red}
+a {color : /* foo */ red }
+a {color /* bar */ : red }

--- a/test/options/space-before-colon/test.expected.css
+++ b/test/options/space-before-colon/test.expected.css
@@ -1,0 +1,5 @@
+a { color: red }
+a{color:red}
+a {color: red}
+a {color: /* foo */ red }
+a {color /* bar */: red }


### PR DESCRIPTION
Set space before `:` in declarations.
See #92.

Example: `{ 'space-before-colon': '' }`

``` scss
// Before:
a {
    top : 0;
    color : tomato;
}

// After:
a {
    top: 0;
    color: tomato;
}
```
