### PR TITLE
New option: space-before-combinator (#92)

### DIFF
--- a/config/csscomb.json
+++ b/config/csscomb.json
@@ -14,6 +14,7 @@
     "remove-empty-rulesets": true,
     "space-after-colon": " ",
     "space-before-colon": "",
+    "space-before-combinator": " ",
     "strip-spaces": true,
     "unitless-zero": true,
     "vendor-prefix-align": true,

--- a/doc/options.md
+++ b/doc/options.md
@@ -408,6 +408,36 @@ a {
 }
 ```
 
+## space-before-combinator
+
+Set space before combinator (for example, in selectors like `p > a`).
+
+Acceptable values:
+
+* `{Number}` — number of whitespaces;
+* `{String}` — string with whitespaces, tabs or line breaks.
+
+Example: `{ 'space-before-combinator': 1 }`
+
+```scss
+// Before:
+p>a { color: panda; }
+
+// After:
+p >a { color: panda; }
+```
+
+Example: `{ 'space-before-combinator': '\n' }`
+
+```scss
+// Before:
+p > a { color: panda; }
+
+// After:
+p
+> a { color: panda; }
+```
+
 ## strip-spaces
 
 Whether to trim trailing spaces.

--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -15,6 +15,7 @@ var OPTIONS = [
     'quotes',
     'strip-spaces',
     'eof-newline',
+    'space-before-combinator',
     'space-before-colon',
     'space-after-colon',
     'sort-order',

--- a/lib/options/space-before-combinator.js
+++ b/lib/options/space-before-combinator.js
@@ -1,0 +1,60 @@
+module.exports = {
+    name: 'space-before-combinator',
+
+    accepts: {
+        number: true,
+        string: /^[ \t\n]*$/
+    },
+
+    /**
+     * Processes tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    process: function(nodeType, node) {
+        if (nodeType !== 'selector') return;
+
+        var value = this.getValue('space-before-combinator');
+
+        for (var i = node.length; i--;) {
+            var subSelector = node[i];
+            for (var j = subSelector.length; j--;) {
+                if (subSelector[j][0] !== 'combinator') continue;
+                if (subSelector[j - 1][0] === 's') {
+                    subSelector[j - 1][1] = value;
+                } else {
+                    subSelector.splice(j, 0, ['s', value]);
+                }
+            }
+        }
+    },
+
+    /**
+     * Detects the value of an option at the tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    detect: function(nodeType, node) {
+        if (nodeType !== 'selector') return;
+
+        var variants = [];
+
+        for (var i = node.length; i--;) {
+            var subSelector = node[i];
+            for (var j = subSelector.length; j--;) {
+                if (subSelector[j][0] !== 'combinator') continue;
+
+                if (subSelector[j - 1][0] === 's') {
+                    variants.push(subSelector[j - 1][1]);
+                } else {
+                    variants.push('');
+                }
+            }
+        }
+
+        return variants;
+    }
+};
+

--- a/test/options/space-before-combinator.js
+++ b/test/options/space-before-combinator.js
@@ -1,0 +1,84 @@
+describe('options/space-before-combinator:', function() {
+    beforeEach(function() {
+        this.filename = __filename;
+    });
+
+    it('Array value => should not change anything', function() {
+        this.comb.configure({ 'space-before-combinator': ['', ' '] });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Invalid string value => should not change anything', function() {
+        this.comb.configure({ 'space-before-combinator': '  nani  ' });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Float number value => should not change anything', function() {
+        this.comb.configure({ 'space-before-combinator': 3.5 });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Integer value => should set proper space before combinator', function() {
+        this.comb.configure({ 'space-before-combinator': 0 });
+        this.shouldBeEqual('test.css', 'test.expected.css');
+    });
+
+    it('Valid string value (spaces only) => should set proper space before combinator', function() {
+        this.comb.configure({ 'space-before-combinator': '  ' });
+        this.shouldBeEqual('test.css', 'test-2.expected.css');
+    });
+
+    it('Valid string value (spaces and newlines) => should set proper space before combinator', function() {
+        this.comb.configure({ 'space-before-combinator': '\n    ' });
+        this.shouldBeEqual('test.css', 'test-3.expected.css');
+    });
+
+    it('Should detect no whitespaces before combinator', function() {
+        this.shouldDetect(
+            ['space-before-combinator'],
+            'a+b { color:red }',
+            { 'space-before-combinator': '' }
+        );
+    });
+
+    it('Should detect a space before combinator', function() {
+        this.shouldDetect(
+            ['space-before-combinator'],
+            'a + b { color:red }',
+            { 'space-before-combinator': ' ' }
+        );
+    });
+
+    it('Should detect a space before combinator in long selector', function() {
+        this.shouldDetect(
+            ['space-before-combinator'],
+            'a + b ~ c>d { color:red }',
+            { 'space-before-combinator': ' ' }
+        );
+    });
+
+    it('Should detect a space before combinator in long selector, test 2', function() {
+        this.shouldDetect(
+            ['space-before-combinator'],
+            'a>b + c + d { color:red }',
+            { 'space-before-combinator': ' ' }
+        );
+    });
+
+    it('Should detect no whitespaces before combinator in long selector', function() {
+        this.shouldDetect(
+            ['space-before-combinator'],
+            'a+b ~ c+d { color:red }',
+            { 'space-before-combinator': '' }
+        );
+    });
+
+    it('Shouldn’t detect whitespaces before combinator in selector without combinators', function() {
+        this.shouldDetect(
+            ['space-before-combinator'],
+            'a { color:red }',
+            {}
+        );
+    });
+});
+

--- a/test/options/space-before-combinator/test-2.expected.css
+++ b/test/options/space-before-combinator/test-2.expected.css
@@ -1,0 +1,10 @@
+a  >b { color: red }
+a  > b { color: red }
+a  >b { color: red }
+a  +b { color: red }
+a  + b { color: red }
+a  +b { color: red }
+a  ~b { color: red }
+a  ~ b { color: red }
+a  ~b { color: red }
+a  ~b  + c  >d { color: red }

--- a/test/options/space-before-combinator/test-3.expected.css
+++ b/test/options/space-before-combinator/test-3.expected.css
@@ -1,0 +1,22 @@
+a
+    >b { color: red }
+a
+    > b { color: red }
+a
+    >b { color: red }
+a
+    +b { color: red }
+a
+    + b { color: red }
+a
+    +b { color: red }
+a
+    ~b { color: red }
+a
+    ~ b { color: red }
+a
+    ~b { color: red }
+a
+    ~b
+    + c
+    >d { color: red }

--- a/test/options/space-before-combinator/test.css
+++ b/test/options/space-before-combinator/test.css
@@ -1,0 +1,10 @@
+a>b { color: red }
+a> b { color: red }
+a >b { color: red }
+a+b { color: red }
+a+ b { color: red }
+a +b { color: red }
+a~b { color: red }
+a~ b { color: red }
+a ~b { color: red }
+a ~b+ c>d { color: red }

--- a/test/options/space-before-combinator/test.expected.css
+++ b/test/options/space-before-combinator/test.expected.css
@@ -1,0 +1,10 @@
+a>b { color: red }
+a> b { color: red }
+a>b { color: red }
+a+b { color: red }
+a+ b { color: red }
+a+b { color: red }
+a~b { color: red }
+a~ b { color: red }
+a~b { color: red }
+a~b+ c>d { color: red }


### PR DESCRIPTION
Set space before combinator (for example, in selectors like `p > a`).
See #92.

Example: `{ 'space-before-combinator': '\n' }`

``` scss
// Before:
p > a { color: panda; }

// After:
p
> a { color: panda; }
```
