### PR TITLE
New option: tab-size (#92)

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -548,6 +548,28 @@ Example: `{ "strip-spaces": true }`
 
 `a { color: red }\t` &rarr; `a { color: red }`
 
+## tab-size
+
+Set tab size (number of spaces to replace hard tabs).
+
+Acceptable values:
+
+* `{Number}` — number of whitespaces;
+
+Example: `{ 'tab-size': 2 }`
+
+```scss
+// Before:
+a{
+	color: panda;
+	}
+
+// After:
+a {
+  color: panda;
+  }
+```
+
 ## template
 
 **Note:** See [configuration docs](configuration.md#override-templates-settings)

--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -23,6 +23,7 @@ var OPTIONS = [
     'space-after-opening-brace',
     'sort-order',
     'block-indent',
+    'tab-size',
     'unitless-zero',
     'vendor-prefix-align'
 ];

--- a/lib/options/tab-size.js
+++ b/lib/options/tab-size.js
@@ -1,0 +1,16 @@
+module.exports = {
+    name: 'tab-size',
+
+    accepts: { number: true },
+
+    /**
+     * Processes tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    process: function(nodeType, node) {
+        if (nodeType !== 's') return;
+        node[0] = node[0].replace(/\t/, this.getValue('tab-size'));
+    }
+};

--- a/test/options/tab-size.js
+++ b/test/options/tab-size.js
@@ -1,0 +1,20 @@
+describe('options/tab-size:', function() {
+    beforeEach(function() {
+        this.filename = __filename;
+    });
+
+    it('Test 1: String value => should not change anything', function() {
+        this.comb.configure({ 'tab-size': '   ' });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Test 2: Float value => should not change anything', function() {
+        this.comb.configure({ 'tab-size': 4.5 });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Test 3: Integer value => should replace tabs with proper number of spaces', function() {
+        this.comb.configure({ 'tab-size': 4 });
+        this.shouldBeEqual('test.css', 'test.expected.css');
+    });
+});

--- a/test/options/tab-size/test.css
+++ b/test/options/tab-size/test.css
@@ -1,0 +1,4 @@
+a {
+	color: tomato;
+	top: 0;
+	}

--- a/test/options/tab-size/test.expected.css
+++ b/test/options/tab-size/test.expected.css
@@ -1,0 +1,4 @@
+a {
+    color: tomato;
+    top: 0;
+    }


### PR DESCRIPTION
Set tab size (number of spaces to replace hard tabs).
See #92.

Example: `{ 'tab-size': 2 }`

``` scss
// Before:
a{
    color: panda;
    }

// After:
a {
  color: panda;
  }
```
