### PR TITLE
New option: space-after-opening-brace (#92)

### DIFF
--- a/config/csscomb.json
+++ b/config/csscomb.json
@@ -14,6 +14,7 @@
     "remove-empty-rulesets": true,
     "space-after-colon": " ",
     "space-after-combinator": " ",
+    "space-after-opening-brace": "\n",
     "space-before-colon": "",
     "space-before-combinator": " ",
     "space-before-opening-brace": "\n",

--- a/doc/options.md
+++ b/doc/options.md
@@ -397,6 +397,36 @@ p >
   a { color: panda; }
 ```
 
+## space-after-opening-brace
+
+Set space after `{`.
+
+Acceptable values:
+
+* `{Number}` — number of whitespaces;
+* `{String}` — string with whitespaces, tabs or line breaks.
+
+Example: `{ 'space-after-opening-brace': 1 }`
+
+```scss
+// Before:
+a {color: panda;}
+
+// After:
+a { color: panda;}
+```
+
+Example: `{ 'space-after-opening-brace': '\n' }`
+
+```scss
+// Before:
+a{color: panda;}
+
+// After:
+a{
+color: panda;}
+```
+
 ## space-before-colon
 
 Set space before `:` in declarations.

--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -20,6 +20,7 @@ var OPTIONS = [
     'space-before-colon',
     'space-after-colon',
     'space-before-opening-brace',
+    'space-after-opening-brace',
     'sort-order',
     'block-indent',
     'unitless-zero',

--- a/lib/options/space-after-opening-brace.js
+++ b/lib/options/space-after-opening-brace.js
@@ -1,0 +1,43 @@
+module.exports = {
+    name: 'space-after-opening-brace',
+
+    accepts: {
+        number: true,
+        string: /^[ \t\n]*$/
+    },
+
+    /**
+     * Processes tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    process: function(nodeType, node) {
+        // If found block node stop at the next one for space check
+        if (nodeType !== 'block' && nodeType !== 'atrulers') return;
+
+        var value = this.getValue('space-after-opening-brace');
+
+        if (node[0][0] === 's') {
+            node[0][1] = value;
+        } else if (value !== '') {
+            node.unshift(['s', value]);
+        }
+    },
+
+    /**
+     * Detects the value of an option at the tree node.
+     *
+     * @param {String} nodeType
+     * @param {node} node
+     */
+    detect: function(nodeType, node) {
+        if (nodeType !== 'block' && nodeType !== 'atrulers') return;
+
+        if (node[0][0] === 's') {
+            return node[0][1];
+        } else {
+            return '';
+        }
+    }
+};

--- a/test/options/space-after-opening-brace.js
+++ b/test/options/space-after-opening-brace.js
@@ -1,0 +1,84 @@
+describe('options/space-after-opening-brace:', function() {
+    beforeEach(function() {
+        this.filename = __filename;
+    });
+
+    it('Array value => should not change anything', function() {
+        this.comb.configure({ 'space-after-opening-brace': ['', ' '] });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Invalid string value => should not change anything', function() {
+        this.comb.configure({ 'space-after-opening-brace': '  nani  ' });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Float number value => should not change anything', function() {
+        this.comb.configure({ 'space-after-opening-brace': 3.5 });
+        this.shouldBeEqual('test.css');
+    });
+
+    it('Integer value => should set proper space after {', function() {
+        this.comb.configure({ 'space-after-opening-brace': 0 });
+        this.shouldBeEqual('test.css', 'test.expected.css');
+    });
+
+    it('Valid string value (spaces only) => should set proper space after {', function() {
+        this.comb.configure({ 'space-after-opening-brace': '  ' });
+        this.shouldBeEqual('test.css', 'test-2.expected.css');
+    });
+
+    it('Valid string value (spaces and newlines) => should set proper space after {', function() {
+        this.comb.configure({ 'space-after-opening-brace': '\n    ' });
+        this.shouldBeEqual('test.css', 'test-3.expected.css');
+    });
+
+    it('Should detect no whitespace', function() {
+        this.shouldDetect(
+            ['space-after-opening-brace'],
+            'a{top:0}',
+            { 'space-after-opening-brace': '' }
+        );
+    });
+
+    it('Should detect whitespace', function() {
+        this.shouldDetect(
+            ['space-after-opening-brace'],
+            'a{\n\ttop:0}',
+            { 'space-after-opening-brace': '\n\t' }
+        );
+    });
+
+    it('Should detect no whitespace (2 blocks)', function() {
+        this.shouldDetect(
+            ['space-after-opening-brace'],
+            'a{top:0} b{\n left:0}',
+            { 'space-after-opening-brace': '' }
+        );
+    });
+
+    it('Should detect whitespace (2 blocks)', function() {
+        this.shouldDetect(
+            ['space-after-opening-brace'],
+            'a{ top:0 } b{left:0}',
+            { 'space-after-opening-brace': ' ' }
+        );
+    });
+
+    it('Should detect no whitespace (3 blocks)', function() {
+        this.shouldDetect(
+            ['space-after-opening-brace'],
+            'a{top:0} b { left: 0 } c{\n\tright:0}',
+            { 'space-after-opening-brace': '' }
+        );
+    });
+
+    it('Should detect whitespace (3 blocks)', function() {
+        this.shouldDetect(
+            ['space-after-opening-brace'],
+            'a{\ntop:0} b{\nleft:0} c{\n  right:0}',
+            { 'space-after-opening-brace': '\n' }
+        );
+    });
+});
+

--- a/test/options/space-after-opening-brace/test-2.expected.css
+++ b/test/options/space-after-opening-brace/test-2.expected.css
@@ -1,0 +1,5 @@
+a{  top: 0}
+a {  top: 0 }
+
+@media print{  a{  top: 0}}
+@media print {  a {  top: 0 } }

--- a/test/options/space-after-opening-brace/test-3.expected.css
+++ b/test/options/space-after-opening-brace/test-3.expected.css
@@ -1,0 +1,11 @@
+a{
+    top: 0}
+a {
+    top: 0 }
+
+@media print{
+    a{
+    top: 0}}
+@media print {
+    a {
+    top: 0 } }

--- a/test/options/space-after-opening-brace/test.css
+++ b/test/options/space-after-opening-brace/test.css
@@ -1,0 +1,5 @@
+a{top: 0}
+a { top: 0 }
+
+@media print{a{top: 0}}
+@media print { a { top: 0 } }

--- a/test/options/space-after-opening-brace/test.expected.css
+++ b/test/options/space-after-opening-brace/test.expected.css
@@ -1,0 +1,5 @@
+a{top: 0}
+a {top: 0 }
+
+@media print{a{top: 0}}
+@media print {a {top: 0 } }


### PR DESCRIPTION
Set space after `{`.
See #92.

Example: `{ 'space-after-opening-brace': '\n' }`

``` scss
// Before:
a {color: panda;}

// After:
a {
color: panda;}
```
