### PR TITLE
Vendor prefix align: Handle declarations without preceding spaces

### DIFF
--- a/lib/options/vendor-prefix-align.js
+++ b/lib/options/vendor-prefix-align.js
@@ -286,6 +286,7 @@ module.exports = (function() {
                 payload: function(info, i) {
                     // `node[i - 1]` can be either space or comment:
                     var whitespaceNode = node[i - 1];
+                    if (!whitespaceNode) return;
                     // If it's a comment, insert an empty space node:
                     if (whitespaceNode[0] !== 's') {
                         whitespaceNode = ['s', ''];

--- a/test/options/vendor-prefix-align.js
+++ b/test/options/vendor-prefix-align.js
@@ -56,6 +56,10 @@ describe('options/vendor-prefix-align', function() {
         this.shouldBeEqual('complex.css', 'complex.expected.css');
     });
 
+    it('Issue 193: should handle declarations without preceding spaces', function() {
+        this.shouldBeEqual('issue-193.css', 'issue-193.expected.css');
+    });
+
     it('Shouldn not detect anything if there are no prefixed groups', function() {
         this.shouldDetect(
             ['vendor-prefix-align'],

--- a/test/options/vendor-prefix-align/issue-193.css
+++ b/test/options/vendor-prefix-align/issue-193.css
@@ -1,0 +1,2 @@
+li {color: #7799c8;
+    font-size: 10px;}

--- a/test/options/vendor-prefix-align/issue-193.expected.css
+++ b/test/options/vendor-prefix-align/issue-193.expected.css
@@ -1,0 +1,2 @@
+li {color: #7799c8;
+    font-size: 10px;}


### PR DESCRIPTION
Fix #193
