### PR TITLE
Add bower_components to config files

### DIFF
--- a/config/csscomb.json
+++ b/config/csscomb.json
@@ -1,7 +1,8 @@
 {
     "exclude": [
         ".git/**",
-        "node_modules/**"
+        "node_modules/**",
+        "bower_components/**"
     ],
     "always-semicolon": true,
     "block-indent": "    ",

--- a/config/yandex.json
+++ b/config/yandex.json
@@ -1,7 +1,8 @@
 {
     "exclude": [
         ".git/**",
-        "node_modules/**"
+        "node_modules/**",
+        "bower_components/**"
     ],
     "sort-order": [
         [

--- a/config/zen.json
+++ b/config/zen.json
@@ -1,7 +1,8 @@
 {
     "exclude": [
         ".git/**",
-        "node_modules/**"
+        "node_modules/**",
+        "bower_components/**"
     ],
     "sort-order": [ [
         "position",


### PR DESCRIPTION
Looking through the example config files, I saw that you included `node_modules`, and thought that it would make a lot of sense to include `bower_components` since so many people use it for client-side assets and it often includes stylesheets.

---

**Changes:**
- Add `bower_components` to example config files

---

If you need anything else from this PR please let me know. Thanks
