### PR TITLE
Consistent usage of double quotes in documentation.

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -238,8 +238,8 @@ Add/remove leading zero in dimensions.
 
 Acceptable values:
 
-    * `true` — add leading zero;
-    * `false` — remove leading zero.
+* `true` — add leading zero;
+* `false` — remove leading zero.
 
 Example: `{ "leading-zero": false }`
 


### PR DESCRIPTION
Since all bundled configs use double quotes, I think it's a good idea to use them in the documentation as well.

Plus `Acceptable values` for [`leading-zero`](https://github.com/csscomb/csscomb.js/blob/master/doc/options.md#leading-zero) were showing up as code because the list is indented 4 spaces.
