### PR TITLE
npmignore non-essential files

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
         "mocha": "1.14.0"
     },
     "main": "./lib/csscomb.js",
+    "files": [
+        "bin",
+        "config",
+        "lib"
+    ],
     "bin": {
         "csscomb": "./bin/csscomb"
     },


### PR DESCRIPTION
npm-install only what is needed to use the package
