### PR TITLE
sort-order: Avoid a isn't string

### DIFF
--- a/lib/options/sort-order.js
+++ b/lib/options/sort-order.js
@@ -231,7 +231,7 @@ module.exports = {
             // Avoid a isn't string. 
             // Using like "filter: alpha(opacity=50);" in some sass file will return a array.
             function getStrFromArr(source) {
-                if (Array.isArray(source) && source[1]) {
+                if (Array.isArray(source)) {
                     return getStrFromArr(source[1]);
                 }
                 return source || '';

--- a/lib/options/sort-order.js
+++ b/lib/options/sort-order.js
@@ -231,10 +231,10 @@ module.exports = {
             // Avoid a isn't string. 
             // Using like "filter: alpha(opacity=50);" in some sass file will return a array.
             function getStrFromArr(source) {
-              if (Array.isArray(source) && source[1]) {
-                return getStrFromArr(source[1]);
-              }
-              return source || '';
+                if (Array.isArray(source) && source[1]) {
+                    return getStrFromArr(source[1]);
+                }
+                return source || '';
             }
 
             // Get property name (i.e. `color`, `-o-animation`):

--- a/lib/options/sort-order.js
+++ b/lib/options/sort-order.js
@@ -228,9 +228,18 @@ module.exports = {
             var prefixes = ['-webkit-', '-moz-', '-ms-', '-o-', ''];
             var prefixesRegExp = /^(-webkit-|-moz-|-ms-|-o-)(.*)$/;
 
+            // Avoid a isn't string. 
+            // Using like "filter: alpha(opacity=50);" in some sass file will return a array.
+            function getStrFromArr(source) {
+              if (Array.isArray(source) && source[1]) {
+                return getStrFromArr(source[1]);
+              }
+              return source || '';
+            }
+
             // Get property name (i.e. `color`, `-o-animation`):
-            a = a.node[1][1][1];
-            b = b.node[1][1][1];
+            a = getStrFromArr(a.node);
+            b = getStrFromArr(b.node);
 
             // Get prefix and unprefixed part. For example:
             // ['-o-animation', '-o-', 'animation']


### PR DESCRIPTION
Using like "filter: alpha(opacity=50);" in some sass file will return a array， not a string.