### PR TITLE
Symlink extensionless config file

### DIFF
--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -221,7 +221,7 @@ CSScomb.getCustomConfig = function getCustomConfig(configPath) {
     configPath = configPath || CSScomb.getCustomConfigPath();
 
     try {
-        config = require(configPath);
+        config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     } catch (e) {
         config = null;
     }

--- a/lib/csscomb.js
+++ b/lib/csscomb.js
@@ -243,7 +243,7 @@ CSScomb.getCustomConfigPath = function getCustomConfigPath(configPath) {
     configPath = configPath || path.join(process.cwd(), '.csscomb.json');
 
     // If we've finally found a config, return its path:
-    if (fs.existsSync(configPath)) return configPath;
+    if (fs.existsSync(configPath)) return fs.realpathSync(configPath);
 
     // If we are in HOME dir already and yet no config file, return a default
     // one from our package.


### PR DESCRIPTION
I'm having trouble with symlinks. I setup a `.csscomb.json` config file in my dotfiles, and when it's installed it's actually a symlink to a `csscomb.json.symlink` file. Similar to https://github.com/holman/dotfiles symlink setup.

```
$ csscomb assets/_scss/404.scss        

/Users/jonrohan/.dotfiles/editor/csscomb.json.symlink:2
  "sort-order": [ [
              ^
Configuration file /Users/jonrohan/.csscomb.json was not found.
```

My `.csscomb.json`

```
$ ll /Users/jonrohan/.csscomb.json
lrwxr-xr-x  1 jonrohan  staff  53 May 12 22:28 /Users/jonrohan/.csscomb.json@ -> /Users/jonrohan/.dotfiles/editor/csscomb.json.symlink
```

What I tracked down was happening was when `require()` was being called, I think it assumes a `js` or `json` file extension. I also found that finding the full path before processing the config fixes it.

```
$ node -v
v0.10.21
$ csscomb -V
3.0.4
```

In this pull I'm using `fs.realpathSync(configPath)` to get the real path of the symlinked file. and I'm also using `JSON.parse(fs.readFileSync(configPath, 'utf8'))` instead of `require()` to read in the config file.