### PR TITLE
Divide `$include` into `$extend`, `$include name` and `$include`

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -336,11 +336,14 @@ If you sort properties in `*.scss` or `*.less` files, you can use one of 3
 keywords in your config:
 
 * `$variable` — for variable declarations (e.g. `$var` in Sass or `@var` in LESS);
-* `$include` — for included mixins (e.g. `@include ...` and `@extend ...` in Sass
-   or `.mixin()` in LESS);
+* `$include` — for all mixins except those that have been specified (e.g. `@include ...` in Sass
+  or `.mixin()` in LESS);
+* `$include mixin-name` — for mixins with specified name (e.g. `@include mixin-name` in Sass
+  or `.mixin-name()` in LESS);
+* `$extend` — for extends (e.g. `@extend ...`; only in Sass);
 * `$import` — for `@import` rules.
 
-Example: `{ "sort-order": [ [ "$variable" ], [ "$include" ], [ "top", "padding" ] ] }`
+Example: `{ "sort-order": [ [ "$variable" ], [ "$include" ], [ "top", "padding" ], [ "$include media" ] ] }`
 
 ```scss
 /* before */
@@ -348,6 +351,9 @@ p {
     padding: 0;
     @include mixin($color);
     $color: tomato;
+    @include media("desktop") {
+        color: black;
+    }
     top: 0;
 }
 
@@ -359,6 +365,10 @@ p {
 
     top: 0;
     padding: 0;
+
+    @include media("desktop") {
+        color: black;
+    }
 }
 ```
 

--- a/doc/options.md
+++ b/doc/options.md
@@ -340,7 +340,7 @@ keywords in your config:
   or `.mixin()` in LESS);
 * `$include mixin-name` — for mixins with specified name (e.g. `@include mixin-name` in Sass
   or `.mixin-name()` in LESS);
-* `$extend` — for extends (e.g. `@extend ...`; only in Sass);
+* `$extend` — for extends (e.g. `@extend .foo` in Sass or `&:extend(.foo)` in LESS);
 * `$import` — for `@import` rules.
 
 Example: `{ "sort-order": [ [ "$variable" ], [ "$include" ], [ "top", "padding" ], [ "$include media" ] ] }`

--- a/src/options/sort-order.js
+++ b/src/options/sort-order.js
@@ -291,7 +291,44 @@ module.exports = {
             propertyName = null;
             // Look for includes:
             if (node.get(i).is('include')) {
-                propertyName = '$include';
+                // Divide `include` into `$extend`,
+                // mixins with specific name (e. g. `$include breakpoint`),
+                // and the rest — `$include`.
+                var includeType;
+                var mixinName;
+
+                // SASS and SCSS both supports `@extend` and `@include`,
+                // but SASS also supports `+mixin-name`
+                if (_this.syntax === 'sass' || _this.syntax === 'scss') {
+                    if (_this.syntax === 'sass' && node.get(i).get(0).content === '+') {
+                        includeType = 'include';
+                        mixinName = node.get(i).get(1).get(0).content;
+                    } else {
+
+                        includeType = node.get(i).get(0).get(0).content;
+
+                        if (includeType === 'include') {
+                            mixinName = node.get(i).get(2).get(0).content;
+                        }
+                    }
+                }
+
+                if (_this.syntax === 'less') {
+                    includeType = 'include';
+                    mixinName = node.get(i).get(0).get(0).content;
+                }
+
+                if (includeType === 'extend') {
+                    propertyName = '$extend';
+                } else {
+                    var includeMixinName = '$include ' + mixinName;
+
+                    if (order.hasOwnProperty(includeMixinName)) {
+                        propertyName = includeMixinName;
+                    } else {
+                        propertyName = '$include';
+                    }
+                }
             } else {
                 for (j = 0, nl = node.get(i).length; j < nl; j++) {
                     currentNode = node.get(i).get(j);

--- a/src/options/sort-order.js
+++ b/src/options/sort-order.js
@@ -294,37 +294,31 @@ module.exports = {
                 // Divide `include` into `$extend`,
                 // mixins with specific name (e. g. `$include breakpoint`),
                 // and the rest — `$include`.
-                var includeType;
-                var mixinName;
+                var include = node.get(i);
+                var includeType = 'include';
+                var includeName;
 
                 // SASS and SCSS both supports `@extend` and `@include`,
                 // but SASS also supports `+mixin-name`
-                if (_this.syntax === 'sass' || _this.syntax === 'scss') {
-                    if (_this.syntax === 'sass' && node.get(i).get(0).content === '+') {
-                        includeType = 'include';
-                        mixinName = node.get(i).get(1).get(0).content;
-                    } else {
+                if (syntax === 'less') {
+                    includeName = include.get(0).get(0).content;
+                } else if (syntax === 'sass' && include.get(0).content === '+') {
+                    includeName = include.get(1).get(0).content;
+                } else {
+                    includeType = include.get(0).get(0).content;
 
-                        includeType = node.get(i).get(0).get(0).content;
-
-                        if (includeType === 'include') {
-                            mixinName = node.get(i).get(2).get(0).content;
-                        }
+                    if (includeType === 'include') {
+                        includeName = include.get(2).get(0).content;
                     }
-                }
-
-                if (_this.syntax === 'less') {
-                    includeType = 'include';
-                    mixinName = node.get(i).get(0).get(0).content;
                 }
 
                 if (includeType === 'extend') {
                     propertyName = '$extend';
                 } else {
-                    var includeMixinName = '$include ' + mixinName;
+                    var includeWithName = '$include ' + includeName;
 
-                    if (order.hasOwnProperty(includeMixinName)) {
-                        propertyName = includeMixinName;
+                    if (order.hasOwnProperty(includeWithName)) {
+                        propertyName = includeWithName;
                     } else {
                         propertyName = '$include';
                     }

--- a/src/options/sort-order.js
+++ b/src/options/sort-order.js
@@ -298,9 +298,36 @@ module.exports = {
                 // If not, proceed with the next node:
                 propertyName = null;
                 // Look for includes:
-                if (node.get(i).is('include') ||
-                    node.get(i).is('extend')) {
-                    propertyName = '$include';
+                if (node.get(i).is('include')) {
+                    // Divide `include` into mixins with specific
+                    // name (e. g. `$include breakpoint`),
+                    // and the rest — `$include`.
+                    var mixinName;
+
+                    // SASS and SCSS both supports `@include`,
+                    // but SASS also supports `+mixin-name`
+                    if (syntax === 'sass' || syntax === 'scss') {
+                        if (syntax === 'sass' &&
+                            node.get(i).get(0).content === '+') {
+                            mixinName = node.get(i).get(1).get(0).content;
+                        } else {
+                            mixinName = node.get(i).get(2).get(0).content;
+                        }
+                    }
+
+                    if (syntax === 'less') {
+                        mixinName = node.get(i).get(0).get(0).content;
+                    }
+
+                    var includeMixinName = '$include ' + mixinName;
+
+                    if (order.hasOwnProperty(includeMixinName)) {
+                        propertyName = includeMixinName;
+                    } else {
+                        propertyName = '$include';
+                    }
+                } else if (node.get(i).is('extend')) {
+                    propertyName = '$extend';
                 } else {
                     for (j = 0, nl = node.get(i).length; j < nl; j++) {
                         currentNode = node.get(i).get(j);

--- a/test/options/sort-order-less/extend.expected.less
+++ b/test/options/sort-order-less/extend.expected.less
@@ -1,0 +1,7 @@
+.block {
+    &:extend(.foo);
+    color: black;
+}
+.a:extend(.b) {
+  color: pink;
+}

--- a/test/options/sort-order-less/extend.less
+++ b/test/options/sort-order-less/extend.less
@@ -1,0 +1,7 @@
+.block {
+    color: black;
+    &:extend(.foo);
+}
+.a:extend(.b) {
+  color: pink;
+}

--- a/test/options/sort-order-less/mixin-4.expected.less
+++ b/test/options/sort-order-less/mixin-4.expected.less
@@ -1,0 +1,9 @@
+.block {
+    .last;
+    .hide-text;
+
+    color: black;
+
+    .media("lap");
+    .media("palm");
+}

--- a/test/options/sort-order-less/mixin-4.less
+++ b/test/options/sort-order-less/mixin-4.less
@@ -1,0 +1,7 @@
+.block {
+    color: black;
+    .media("lap");
+    .media("palm");
+    .last;
+    .hide-text;
+}

--- a/test/options/sort-order-less/test.js
+++ b/test/options/sort-order-less/test.js
@@ -91,4 +91,11 @@ describe.skip('options/sort-order (less)', function() {
             this.shouldBeEqual('mixin-3.less', 'mixin-3.expected.less');
         });
     });
+
+    it('Should sort included mixins with specified name. Test 4', function() {
+        this.comb.configure({ 'sort-order': [
+            ['$include'], ['color'], ['$include media']
+        ] });
+        this.shouldBeEqual('mixin-4.less', 'mixin-4.expected.less');
+    });
 });

--- a/test/options/sort-order-less/test.js
+++ b/test/options/sort-order-less/test.js
@@ -90,12 +90,19 @@ describe('options/sort-order (less)', function() {
             ] });
             this.shouldBeEqual('mixin-3.less', 'mixin-3.expected.less');
         });
-    });
 
-    it('Should sort included mixins with specified name. Test 4', function() {
-        this.comb.configure({ 'sort-order': [
-            ['$include'], ['color'], ['$include media']
-        ] });
-        this.shouldBeEqual('mixin-4.less', 'mixin-4.expected.less');
+        it('Should sort included mixins with specified name. Test 4', function() {
+            this.comb.configure({ 'sort-order': [
+                ['$include'], ['color'], ['$include media']
+            ] });
+            this.shouldBeEqual('mixin-4.less', 'mixin-4.expected.less');
+        });
+
+        it('Should sort @extend-s', function() {
+            this.comb.configure({ 'sort-order': [
+                ['$extend', 'color']
+            ] });
+            this.shouldBeEqual('extend.less', 'extend.expected.less');
+        });
     });
 });

--- a/test/options/sort-order-sass/include-specified-1.expected.sass
+++ b/test/options/sort-order-sass/include-specified-1.expected.sass
@@ -1,0 +1,12 @@
+.block
+  +last
+  +hide-text
+
+  color: black
+
+  +media(lap)
+    color: green
+
+  +media(palm)
+    color: red
+

--- a/test/options/sort-order-sass/include-specified-1.sass
+++ b/test/options/sort-order-sass/include-specified-1.sass
@@ -1,0 +1,10 @@
+.block
+  color: black
+  +media(lap)
+    color: green
+
+  +media(palm)
+    color: red
+
+  +last
+  +hide-text

--- a/test/options/sort-order-sass/include-specified-2.expected.sass
+++ b/test/options/sort-order-sass/include-specified-2.expected.sass
@@ -1,0 +1,12 @@
+.block
+  @include last
+  @include hide-text
+
+  color: black
+
+  @include media(lap)
+    color: green
+
+  @include media(palm)
+    color: red
+

--- a/test/options/sort-order-sass/include-specified-2.sass
+++ b/test/options/sort-order-sass/include-specified-2.sass
@@ -1,0 +1,10 @@
+.block
+  color: black
+  @include media(lap)
+    color: green
+
+  @include media(palm)
+    color: red
+
+  @include last
+  @include hide-text

--- a/test/options/sort-order-sass/test.js
+++ b/test/options/sort-order-sass/test.js
@@ -58,9 +58,23 @@ describe.skip('options/sort-order (sass)', function() {
 
         it('Should sort @extend-s', function() {
             this.comb.configure({ 'sort-order': [
-                ['$include', 'color']
+                ['$extend', 'color']
             ] });
             this.shouldBeEqual('extend.sass', 'extend.expected.sass');
+        });
+
+        it.skip('Should sort @include-s with specified name. Test 1', function() {
+            this.comb.configure({ 'sort-order': [
+                ['$include'], ['color'], ['$include media']
+            ] });
+            this.shouldBeEqual('include-specified-1.sass', 'include-specified-1.expected.sass');
+        });
+
+        it.skip('Should sort @include-s with specified name. Test 2', function() {
+            this.comb.configure({ 'sort-order': [
+                ['$include'], ['color'], ['$include media']
+            ] });
+            this.shouldBeEqual('include-specified-2.sass', 'include-specified-2.expected.sass');
         });
 
         it('Should sort properties inside blocks passed to mixins', function() {

--- a/test/options/sort-order-sass/test.js
+++ b/test/options/sort-order-sass/test.js
@@ -56,7 +56,7 @@ describe('options/sort-order (sass)', function() {
             this.shouldBeEqual('include.sass', 'include.expected.sass');
         });
 
-        it('Should sort @extend-s', function() {
+        it.skip('Should sort @extend-s', function() {
             this.comb.configure({ 'sort-order': [
                 ['$extend', 'color']
             ] });

--- a/test/options/sort-order-scss/include-specified.expected.scss
+++ b/test/options/sort-order-scss/include-specified.expected.scss
@@ -1,0 +1,13 @@
+.block {
+    @include last;
+    @include hide-text;
+
+    color: black;
+
+    @include media("lap") {
+        color: green;
+    }
+    @include media("palm") {
+        color: red;
+    }
+}

--- a/test/options/sort-order-scss/include-specified.scss
+++ b/test/options/sort-order-scss/include-specified.scss
@@ -1,0 +1,11 @@
+.block {
+    color: black;
+    @include media("lap") {
+        color: green;
+    }
+    @include media("palm") {
+        color: red;
+    }
+    @include last;
+    @include hide-text;
+}

--- a/test/options/sort-order-scss/test.js
+++ b/test/options/sort-order-scss/test.js
@@ -70,9 +70,16 @@ describe.skip('options/sort-order (scss)', function() {
             this.shouldBeEqual('include.scss', 'include.expected.scss');
         });
 
+        it('Should sort @include-s with specified name', function() {
+            this.comb.configure({ 'sort-order': [
+                ['$include'], ['color'], ['$include media']
+            ] });
+            this.shouldBeEqual('include-specified.scss', 'include-specified.expected.scss');
+        });
+
         it('Should sort @extend-s', function() {
             this.comb.configure({ 'sort-order': [
-                ['$include', 'color']
+                ['$extend', 'color']
             ] });
             this.shouldBeEqual('extend.scss', 'extend.expected.scss');
         });


### PR DESCRIPTION
I've made separation as many peoples from community wanted (so am I :)). I was inspired by @jeroenransijn's [commit](https://github.com/jeroenransijn/csscomb.js/commit/9165d87bb56a49aa33d97db34401aa1c1dcbbfbe) and @denisborovikov's [commit](https://github.com/denisborovikov/csscomb.js/commit/0aad4fc9a51f9b6b343cadb278f661fa2a714d09). Their implementations are only for SCSS and for outdated CSSComb. Mine is for all syntaxes and with tests and documentation.

There are three caveats.

1. When I made test for `*.sass` I've faced the problem from #332. Despite sorting works good `.sass` file is incorrect because of this issue. I've commented out tests for `*.sass`.

2. I've not found `extend ` support for LESS in CSSComb, so `extend` is only for Sass (both syntaxes).

3. If you publish this feature right now users can be little confused, because `@extend` by default is leftover now, not a `$include`. `@extend`'s position in declaration block doesn't break compiled Sass, though.

Closes #143, #204, #356.