### PR TITLE
add rule-delimiter option

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -29,6 +29,7 @@ Here is a full list in the same order they are applied while processing css:
 - [unitless-zero](#unitless-zero)
 - [tab-size](#tab-size)
 - [vendor-prefix-align](#vendor-prefix-align)
+- [rule-delimiter](#rule-delimiter)
 
 Following options are ignored while processing `*.sass` files:
 
@@ -893,6 +894,67 @@ a
     background:    -moz-linear-gradient(top, #fff 0, #eee 100%);
     background:         linear-gradient(to bottom, #fff 0, #eee 100%);
 }
+```
+
+## rule-delimiter
+
+Number of line breaks after a ruleset or atruleb.
+
+Acceptable values:
+
+* `{Number}` — number of newlines;
+* `{String}` — string with line breaks.
+
+Example: `{ "rule-delimiter":  1}`
+
+```scss
+// Before:
+.foo {
+    @import border-radius(5px);
+    background: red;
+    .bar {
+        .test {
+            height: 50px;
+        }
+    }
+}.bar {
+    border: 1px solid red;
+    @media (min-width: 500px) {
+        width: 50px;
+    }
+}
+
+// After:
+.foo {
+    @import border-radius(5px);
+    background: red;
+
+    .bar {
+        .test {
+            height: 50px;
+        }
+    }
+}
+
+.bar {
+    border: 1px solid red;
+
+    @media (min-width: 500px) {
+        width: 50px;
+    }
+}
+```
+
+Example: `{ "rule-delimiter": "\n\n" }`
+
+```css
+// Before:
+.foo {background: red;}.bar{border: 1px solid red;}
+
+// After:
+.foo {background: red;}
+
+.bar{border: 1px solid red;}
 ```
 
 ## verbose

--- a/lib/options/rule-delimiter.js
+++ b/lib/options/rule-delimiter.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var gonzales = require('gonzales-pe');
+
+module.exports = (function() {
+    var valueFromSettings;
+    var value;
+
+    function findAtRules(node) {
+        var space = gonzales.createNode({ type: 'space', content: value });
+        
+        node.forEach('atruleb', function(atRuleNode, index) {
+            // for every atruleb - check for preceding space
+            var prevNode = node.get(index - 1);
+            if (prevNode) {
+                if (prevNode.is('space')) {
+                    prevNode.content = value;
+                    return;
+                } else {
+                    node.insert(index, space);
+                }
+            }
+        });
+    }
+
+    function findRuleSets(node) {
+        var space = gonzales.createNode({ type: 'space', content: value });
+        
+        node.forEach('ruleset', function(ruleSetNode, index) {
+            // for every ruleset - check for preceding space
+            var prevNode = node.get(index - 1);
+            if (prevNode) {
+                if (prevNode.is('space')) {
+                    prevNode.content = value;
+                    return;
+                } else {
+                    node.insert(index, space);
+                }
+            }
+        });
+    }
+
+    function processBlock(x) {
+        // XXX: Hack for braces
+        if (x.is('braces') || x.is('id')) return;
+        
+        value = valueFromSettings;
+
+        // check all @rules
+        findAtRules(x);
+
+        // check all rulesets
+        findRuleSets(x);
+
+        x.forEach(function(node) {
+            if (!node.is('block')) return processBlock(node);
+
+            // check all @rules
+            findAtRules(node);
+
+            // check all rulesets
+            findRuleSets(node);
+
+            processBlock(node);
+        });
+    }
+
+    return {
+        name: 'rule-delimiter',
+
+        syntax: ['scss', 'css', 'less'],
+
+        runBefore: 'block-indent',
+
+        setValue: function(value) {
+            var regex = /^[\n]*$/;
+
+            if (typeof value === 'number') {
+                value = new Array(Math.round(value) + 2).join('\n');
+            } else if (typeof value === 'string' && !value.match(regex)) {
+                var err = 'The option only accepts the newline character or numbers (\\n), you provided %s';
+                throw new Error(err, value);
+            }
+
+            return value;
+        },
+
+        process: function(node) {
+            valueFromSettings = this.getValue('rule-delimiter');
+
+            if (!node.is('stylesheet')) return;
+            processBlock(node);
+        }
+    };
+})();

--- a/test/core/use/test.js
+++ b/test/core/use/test.js
@@ -8,6 +8,7 @@ describe('.use()', function() {
         var expected = [
           'always-semicolon',
           'remove-empty-rulesets',
+          'rule-delimiter',
           'color-case',
           'color-shorthand',
           'element-case',

--- a/test/options/rule-delimiter-css/rule-delimiter.css
+++ b/test/options/rule-delimiter-css/rule-delimiter.css
@@ -1,0 +1,1 @@
+.foo {background: red;}.bar{border: 1px solid red;}

--- a/test/options/rule-delimiter-css/rule-delimiter.expected.css
+++ b/test/options/rule-delimiter-css/rule-delimiter.expected.css
@@ -1,0 +1,3 @@
+.foo {background: red;}
+
+.bar{border: 1px solid red;}

--- a/test/options/rule-delimiter-css/test.js
+++ b/test/options/rule-delimiter-css/test.js
@@ -1,0 +1,25 @@
+/* global describe, it */
+'use strict';
+
+describe('options/rule-delimiter:css', function() {
+    it('String value => should insert 1 newline between rulesets', function() {
+        this.comb.configure({ 'rule-delimiter': '\n\n' });
+        this.shouldBeEqual('rule-delimiter.css', 'rule-delimiter.expected.css');
+    });
+
+    it('Numeric value => should insert 1 newline between rulesets', function() {
+        this.comb.configure({ 'rule-delimiter': 1 });
+        this.shouldBeEqual('rule-delimiter.css', 'rule-delimiter.expected.css');
+    });
+
+    it('Invalid string value => should should not change anything', function() {
+        this.comb.configure({ 'rule-delimiter': 'foo' });
+
+        this.shouldBeEqual('rule-delimiter.css');
+    });
+
+    it('Float number value => should be rounded', function() {
+        this.comb.configure({ 'rule-delimiter': 0.5 });
+        this.shouldBeEqual('rule-delimiter.css', 'rule-delimiter.expected.css');
+    });
+});

--- a/test/options/rule-delimiter-less/rule-delimiter.expected.less
+++ b/test/options/rule-delimiter-less/rule-delimiter.expected.less
@@ -1,0 +1,19 @@
+.foo {
+  .border-radius(5px);
+  background: red;
+
+.bar {
+
+.test {
+      height: 50px;
+    }
+  }
+}
+
+.bar {
+  border: 1px solid red;
+
+@media (min-width: 500px) {
+    width: 50px;
+  }
+}

--- a/test/options/rule-delimiter-less/rule-delimiter.less
+++ b/test/options/rule-delimiter-less/rule-delimiter.less
@@ -1,0 +1,14 @@
+.foo {
+  .border-radius(5px);
+  background: red;
+  .bar {
+    .test {
+      height: 50px;
+    }
+  }
+}.bar {
+  border: 1px solid red;
+  @media (min-width: 500px) {
+    width: 50px;
+  }
+}

--- a/test/options/rule-delimiter-less/test.js
+++ b/test/options/rule-delimiter-less/test.js
@@ -1,0 +1,25 @@
+/* global describe, it */
+'use strict';
+
+describe('options/rule-delimiter:less', function() {
+    it('String value => should insert 1 newline between rulesets', function() {
+        this.comb.configure({ 'rule-delimiter': '\n\n' });
+        this.shouldBeEqual('rule-delimiter.less', 'rule-delimiter.expected.less');
+    });
+
+    it('Numeric value => should insert 1 newline between rulesets', function() {
+        this.comb.configure({ 'rule-delimiter': 1 });
+        this.shouldBeEqual('rule-delimiter.less', 'rule-delimiter.expected.less');
+    });
+
+    it('Invalid string value => should should not change anything', function() {
+        this.comb.configure({ 'rule-delimiter': 'foo' });
+
+        this.shouldBeEqual('rule-delimiter.less');
+    });
+
+    it('Float number value => should be rounded', function() {
+        this.comb.configure({ 'rule-delimiter': 0.5 });
+        this.shouldBeEqual('rule-delimiter.less', 'rule-delimiter.expected.less');
+    });
+});

--- a/test/options/rule-delimiter-scss/rule-delimiter.expected.scss
+++ b/test/options/rule-delimiter-scss/rule-delimiter.expected.scss
@@ -1,0 +1,19 @@
+.foo {
+  @import border-radius(5px);
+  background: red;
+
+.bar {
+
+.test {
+      height: 50px;
+    }
+  }
+}
+
+.bar {
+  border: 1px solid red;
+
+@media (min-width: 500px) {
+    width: 50px;
+  }
+}

--- a/test/options/rule-delimiter-scss/rule-delimiter.scss
+++ b/test/options/rule-delimiter-scss/rule-delimiter.scss
@@ -1,0 +1,14 @@
+.foo {
+  @import border-radius(5px);
+  background: red;
+  .bar {
+    .test {
+      height: 50px;
+    }
+  }
+}.bar {
+  border: 1px solid red;
+  @media (min-width: 500px) {
+    width: 50px;
+  }
+}

--- a/test/options/rule-delimiter-scss/test.js
+++ b/test/options/rule-delimiter-scss/test.js
@@ -1,0 +1,25 @@
+/* global describe, it */
+'use strict';
+
+describe('options/rule-delimiter:scss', function() {
+    it('String value => should insert 1 newline between rulesets', function() {
+        this.comb.configure({ 'rule-delimiter': '\n\n' });
+        this.shouldBeEqual('rule-delimiter.scss', 'rule-delimiter.expected.scss');
+    });
+
+    it('Numeric value => should insert 1 newline between rulesets', function() {
+        this.comb.configure({ 'rule-delimiter': 1 });
+        this.shouldBeEqual('rule-delimiter.scss', 'rule-delimiter.expected.scss');
+    });
+
+    it('Invalid string value => should should not change anything', function() {
+        this.comb.configure({ 'rule-delimiter': 'foo' });
+
+        this.shouldBeEqual('rule-delimiter.scss');
+    });
+
+    it('Float number value => should be rounded', function() {
+        this.comb.configure({ 'rule-delimiter': 0.5 });
+        this.shouldBeEqual('rule-delimiter.scss', 'rule-delimiter.expected.scss');
+    });
+});


### PR DESCRIPTION
Opening in favour of #369 as it seems to have gone cold. Fixes #210.

Includes support for less, scss and css. The following has been accounted for:

* Media queries
* Nested rules
* at-root
* Mixins (@ include)

@tonyganch opening this against master as the dev branch is completely broken at the moment. Lots of users have requested this and it is blocking my team from using at the moment so I'm willing to work as much as possible to get this one in.