### PR TITLE
Add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "homepage": "http://csscomb.com/",
     "author": "Mikhail Troshev <mishanga@yandex-team.ru>",
     "repository": "https://github.com/csscomb/csscomb.js",
+    "license": "MIT",
     "maintainers": [
         {
             "name": "Tony Ganch",


### PR DESCRIPTION
Adding license type to package.json helps license tools to identify this package's license, e.g. license-checker or license-report.