### PR TITLE
Add new --tty-mode option for cli

### DIFF
--- a/doc/usage-cli.md
+++ b/doc/usage-cli.md
@@ -37,6 +37,7 @@ csscomb -h
     -c, --config [path]  configuration file path
     -d, --detect         detect mode (would return detected options)
     -l, --lint           in case some fixes needed returns an error
+    -t, --tty-mode       execution in TTY mode (useful, when running tool using external app, e.g. IDE)
 ```
 
 ### config

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,7 +43,7 @@ if (options.detect) {
 var config = getConfig();
 comb.configure(config);
 
-if (process.stdin.isTTY) {
+if (options.ttymode || process.stdin.isTTY) {
   processFiles(options._);
 } else {
   processSTDIN();
@@ -58,7 +58,8 @@ function getOptions() {
       detect: 'd',
       lint: 'l',
       help: 'h',
-      verbose: 'v'
+      verbose: 'v',
+      'tty-mode': 't'
     }
   };
   return parseArgs(process.argv.slice(2), parserOptions);
@@ -83,7 +84,9 @@ function displayHelp() {
     '    -h, --help',
     '        Display help message.',
     '    -v, --verbose',
-    '        Whether to print logging info.'
+    '        Whether to print logging info.',
+    '    -t, --tty-mode',
+    '        Run the tool in TTY mode using external app (e.g. IDE).'
   ];
   process.stdout.write(help.join('\n'));
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,7 +43,7 @@ if (options.detect) {
 var config = getConfig();
 comb.configure(config);
 
-if (options.ttymode || process.stdin.isTTY) {
+if (options['tty-mode'] || process.stdin.isTTY) {
   processFiles(options._);
 } else {
   processSTDIN();


### PR DESCRIPTION
Added a new option "--tty-mode", which helps to run csscomb from another app.
I need to run csscomb using "external tools" in WebStorm.
In that case the only way to make it working is to add an additional option, which allows to run the tool as if it would be in TTY mode.
Otherwise csscomb just finishes it's execution since there is no input from stdin.