### PR TITLE
Only call functions on existing sibling nodes

### DIFF
--- a/src/options/remove-empty-rulesets.js
+++ b/src/options/remove-empty-rulesets.js
@@ -25,7 +25,8 @@ module.exports = (function() {
   function mergeAdjacentWhitespace(node) {
     var i = node.content.length - 1;
     while (i-- > 0) {
-      if (node.get(i).is('space') && node.get(i + 1).is('space')) {
+      if (node.get(i).is('space') &&
+          node.get(i + 1) && node.get(i + 1).is('space')) {
         node.get(i).content += node.get(i + 1).content;
         node.removeChild(i + 1);
       }

--- a/src/options/space-after-colon.js
+++ b/src/options/space-after-colon.js
@@ -27,7 +27,7 @@ module.exports = {
         return null;
 
       // Remove any spaces after colon:
-      if (parent.get(i + 1).is('space'))
+      if (parent.get(i + 1) && parent.get(i + 1).is('space'))
           parent.removeChild(i + 1);
       // If the value set in config is not empty, add spaces:
       if (value !== '') {
@@ -51,8 +51,10 @@ module.exports = {
     let detected = [];
 
     ast.traverseByType('propertyDelimiter', function(delimiter, i, parent) {
-      if (parent.get(i + 1).is('space')) {
-        detected.push(parent.get(i + 1).content);
+      var nextNode = parent.get(i + 1);
+
+      if (nextNode.is('space')) {
+        detected.push(nextNode.content);
       } else {
         detected.push('');
       }

--- a/src/options/space-after-combinator.js
+++ b/src/options/space-after-combinator.js
@@ -23,8 +23,10 @@ module.exports = {
     let value = this.value;
 
     ast.traverseByType('combinator', function(combinator, i, parent) {
-      if (parent.get(i + 1).is('space')) {
-        parent.get(i + 1).content = value;
+      var nextNode = parent.get(i + 1);
+
+      if (nextNode && nextNode.is('space')) {
+        nextNode.content = value;
       } else {
         var space = gonzales.createNode({
           type: 'space',
@@ -44,8 +46,10 @@ module.exports = {
     let detected = [];
 
     ast.traverseByType('combinator', function(combinator, i, parent) {
-      if (parent.get(i + 1).is('space')) {
-        detected.push(parent.get(i + 1).content);
+      var nextNode = parent.get(i + 1);
+
+      if (nextNode.is('space')) {
+        detected.push(nextNode.content);
       } else {
         detected.push('');
       }

--- a/src/options/space-after-selector-delimiter.js
+++ b/src/options/space-after-selector-delimiter.js
@@ -26,6 +26,7 @@ module.exports = {
       if (parent.is('arguments')) return;
 
       var nextNode = parent.get(i + 1);
+      if (!nextNode) return;
 
       if (nextNode.is('space')) {
         nextNode.content = value;

--- a/src/options/space-before-colon.js
+++ b/src/options/space-before-colon.js
@@ -51,8 +51,10 @@ module.exports = {
     let detected = [];
 
     ast.traverseByType('propertyDelimiter', function(delimiter, i, parent) {
-      if (parent.get(i - 1).is('space')) {
-        detected.push(parent.get(i - 1).content);
+      var previousNode = parent.get(i - 1);
+
+      if (previousNode && previousNode.is('space')) {
+        detected.push(previousNode.content);
       } else {
         detected.push('');
       }

--- a/src/options/space-before-combinator.js
+++ b/src/options/space-before-combinator.js
@@ -23,8 +23,9 @@ module.exports = {
     let value = this.value;
 
     ast.traverseByType('combinator', function(combinator, i, parent) {
-      if (parent.get(i - 1).is('space')) {
-        parent.get(i - 1).content = value;
+      var previousNode = parent.get(i - 1);
+      if (previousNode && previousNode.is('space')) {
+        previousNode.content = value;
       } else {
         var space = gonzales.createNode({
           type: 'space',
@@ -44,8 +45,10 @@ module.exports = {
     let detected = [];
 
     ast.traverseByType('combinator', function(combinator, i, parent) {
-      if (parent.get(i - 1).is('space')) {
-        detected.push(parent.get(i - 1).content);
+      var previousNode = parent.get(i - 1);
+
+      if (previousNode && previousNode.is('space')) {
+        detected.push(previousNode.content);
       } else {
         detected.push('');
       }

--- a/src/options/space-before-selector-delimiter.js
+++ b/src/options/space-before-selector-delimiter.js
@@ -26,7 +26,8 @@ module.exports = {
       if (parent.is('arguments')) return;
 
       var previousNode = parent.get(i - 1);
-      if (previousNode.is('space')) {
+
+      if (previousNode && previousNode.is('space')) {
         previousNode.content = value;
       } else {
         var space = gonzales.createNode({
@@ -50,7 +51,8 @@ module.exports = {
       if (parent.is('arguments')) return;
 
       var previousNode = parent.get(i - 1);
-      if (previousNode.is('space')) {
+
+      if (previousNode && previousNode.is('space')) {
         detected.push(previousNode.content);
       } else {
         detected.push('');

--- a/src/options/space-between-declarations.js
+++ b/src/options/space-between-declarations.js
@@ -82,7 +82,7 @@ module.exports = (function() {
         }
 
         var nextNode = parent.get(i + 1);
-        if (nextNode.is('space')) {
+        if (nextNode && nextNode.is('space')) {
           nextNode.content = value;
         } else {
           var space = gonzales.createNode({


### PR DESCRIPTION
The csscomb process is getting stuck on Node 7.8 when trying to call functions on nonexistent sibling nodes, this adds safeguards against it.

**Steps to reproduce on the currently released version:**

```
$ node -v
v7.8.0
```

```
$ cat test.scss
a {
  color: green;
  > b { color: red; }
}
```

```
$ csscomb test.scss
(node:99773) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'is' of null
(node:99773) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

When catching the `unhandledRejection` event on the node `process` you can see the proper stack trace:
```
TypeError: Cannot read property 'is' of null
    at Node.<anonymous> ([...]/csscomb/lib/options/space-before-combinator.js:26:28)
    at gonzales-pe/lib/gonzales.js:299:41
    at Node.traverse ([...]/gonzales-pe/lib/gonzales.js:279:6)
    at Node.traverse ([...]/gonzales-pe/lib/gonzales.js:284:36)
    at Node.traverse ([...]/gonzales-pe/lib/gonzales.js:284:36)
    at Node.traverse ([...]/gonzales-pe/lib/gonzales.js:284:36)
    at Node.traverse ([...]/gonzales-pe/lib/gonzales.js:284:36)
    at Node.traverse ([...]/gonzales-pe/lib/gonzales.js:284:36)
    at Node.traverseByType ([...]/gonzales-pe/lib/gonzales.js:298:11)
    at Plugin.process ([...]/csscomb/lib/options/space-before-combinator.js:25:9)
```