### PR TITLE
Add empty new line in the end of cli help text

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -88,7 +88,7 @@ function displayHelp() {
     '    -t, --tty-mode',
     '        Run the tool in TTY mode using external app (e.g. IDE).'
   ];
-  process.stdout.write(help.join('\n'));
+  process.stdout.write(help.join('\n') + '\n');
 }
 
 function detectConfig() {


### PR DESCRIPTION
Run:
`csscomb -h`

Get this:
![help-no-trailing-new-line](https://cloud.githubusercontent.com/assets/3609840/26024342/1c1b1682-37d8-11e7-93f8-28f12911f342.png)

Please, add trailing new line for cli help to keep professional look and feel on the package.