### PR TITLE
Fix bug in the insertNewlines() of lines-between-rulesets.js

### DIFF
--- a/src/options/lines-between-rulesets.js
+++ b/src/options/lines-between-rulesets.js
@@ -238,10 +238,12 @@ let option = {
         prevChild = node.get(lastNonCommentIndex);
       }
 
-      if (prevChild.is('space')) {
-        this.insertNewlinesAsString(prevChild);
-      } else {
-        this.insertNewlinesAsNode(prevChild);
+      if (prevChild) {
+        if (prevChild.is('space')) {
+          this.insertNewlinesAsString(prevChild);
+        } else {
+          this.insertNewlinesAsNode(prevChild);
+        }
       }
     }
   }


### PR DESCRIPTION
I use csscomb via [gulp-csscomb ](https://github.com/koistya/gulp-csscomb)and get this before and after making the current PR changes:

![lines-between-rulesets-bug](https://cloud.githubusercontent.com/assets/3609840/26024645/5924a416-37de-11e7-8d66-1ed33ef5d583.png)

