### PR TITLE
Add detect() method for the space-between-declarations.js

### DIFF
--- a/src/options/lines-between-rulesets.js
+++ b/src/options/lines-between-rulesets.js
@@ -244,6 +244,34 @@ let option = {
         this.insertNewlinesAsNode(prevChild);
       }
     }
+  },
+
+  /**
+   * Detects the value of this option in ast.
+   * @param {Node} ast
+   * @return {Array?} List of detected values
+   */
+  detect(ast) {
+    var detected = [];
+    var ruleNode = false;
+
+    ast.forEach((node, index) => {
+      if (ruleNode && node.is('space')) {
+        if (node.end.line && node.start.line) {
+          var lines = node.end.line - node.start.line;
+          if (lines > 0) {
+            detected.push(lines);
+          }
+        }
+        ruleNode = false;
+      }
+
+      if (node.is('ruleset') || node.is('atrule')) {
+        ruleNode = true;
+      }
+    });
+
+    return detected;
   }
 };
 


### PR DESCRIPTION
To reproduce:

Put mystyle.css into the project root directory.
[mystyle.css.txt](https://github.com/csscomb/csscomb.js/files/998792/mystyle.css.txt)

Run:
`csscomb -d mystyle.css`

Observe:
![no-detect-lines-between-rulesets](https://cloud.githubusercontent.com/assets/3609840/26027500/7ceca68a-3817-11e7-923e-a0fb2d01510b.png)

Apply the current PR changes, run the command again and observe:
![lines-between-rulesets-detected](https://cloud.githubusercontent.com/assets/3609840/26027514/aa68b9fa-3817-11e7-8d76-d87f264214c3.png)

