### PR TITLE
Add detect() method for the tab-size.js

### DIFF
--- a/src/options/tab-size.js
+++ b/src/options/tab-size.js
@@ -22,5 +22,38 @@ module.exports = {
     ast.traverseByType('space', function(space) {
       space.content = space.content.replace(/\t/, value);
     });
+  },
+
+  /**
+  * Detects the value of this option in ast.
+  * @param {Node} ast
+  * @return {Array?} List of detected values
+  */
+  detect(ast) {
+    var detected = [];
+
+    ast.traverseByType('block', block => {
+      var spaces = 0;
+      var tabs = 0;
+
+      block.forEach(blockContent => {
+        if (blockContent.is('space')) {
+          spaces = blockContent.content.replace(/\n/g, '');
+          tabs = spaces.match(/\t/g);
+          // It is very rare case when tabs are used in a file instead of
+          // whitespaces and it requires a lot of efforts to find the tab size
+          // in a particular environment, ... so we imply that tab size = 2.
+          tabs = tabs ? tabs.length * 2 : 0;
+          spaces = spaces.match(/( )/g);
+          spaces = spaces ? spaces.length + tabs : tabs;
+
+        } else if (spaces && blockContent.is('declaration')) {
+          detected.push(spaces);
+          spaces = 0;
+        }
+      });
+    });
+
+    return detected;
   }
 };


### PR DESCRIPTION
To reproduce:

Put mystyle.css into the project root directory.
[mystyle.css.txt](https://github.com/csscomb/csscomb.js/files/1007107/mystyle.css.txt)

Run:
`csscomb -d mystyle.css`

Observe:
![no-tab-size](https://cloud.githubusercontent.com/assets/3609840/26146324/7228fa6c-3af8-11e7-9230-8966a3708cde.png)

Apply the current PR changes, run the command again and observe:
![tab-size-detected](https://cloud.githubusercontent.com/assets/3609840/26146349/87f03f04-3af8-11e7-9077-2f7ff6153452.png)



