### PR TITLE
Update vow-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "minimatch": "3.0.2",
     "minimist": "1.1.x",
     "vow": "0.4.4",
-    "vow-fs": "0.3.2"
+    "vow-fs": "0.3.6"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
Update vow-fs to prevent warnings:
```
npm WARN deprecated node-uuid@1.4.0: Use uuid module instead
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

```