### PR TITLE
Fixed parser options. tty-mode now parsed as boolean.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -53,7 +53,7 @@ if (options['tty-mode'] || process.stdin.isTTY) {
 
 function getOptions() {
   var parserOptions = {
-    boolean: ['help', 'lint', 'verbose'],
+    boolean: ['help', 'lint', 'verbose', 'tty-mode'],
     alias: {
       config: 'c',
       detect: 'd',


### PR DESCRIPTION
**Run:**
csscomb --tty-mode somefile.js 

**Before fix:**
options['tty-mode'] == 'somefile.js'
files = []

**After fix:**
options['tty-mode'] == true
files = ['somefile.js']

It broke the ability to use csscomb with lint-staged. See [related issue](https://github.com/okonet/lint-staged/issues/146)
