### PR TITLE
Fix ast.remove is not a function error

### DIFF
--- a/src/options/block-indent.js
+++ b/src/options/block-indent.js
@@ -45,7 +45,7 @@ let option = {
       var spaces = whitespaceNode.content.replace(/\n[ \t]+/gm, '\n');
 
       if (spaces === '') {
-        ast.remove(i);
+        ast.removeChild(i);
       } else {
         whitespaceNode.content = spaces;
       }


### PR DESCRIPTION
This PR fixes an error that occurs when `"eof-newline": false,` as described here: https://github.com/csscomb/csscomb.js/issues/501.

@aiboy 