### PR TITLE
flatten result processPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
+    "array.prototype.flatten": "^1.2.1",
     "babel-polyfill": "6.23.0",
     "glob": "latest",
     "gonzales-pe": "^3.4.7",

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,7 @@ var fs = require('fs');
 var parseArgs = require('minimist');
 var path = require('path');
 var os = require('os');
+var flatten = require('array.prototype.flatten');
 
 var Comb = require('./csscomb');
 var Errors = require('./errors');
@@ -151,6 +152,7 @@ function processFiles(files) {
     process.stderr.write(error.stack);
     process.exit(1);
   }).then(c => {
+    c = flatten(c, 1);
     var tbchanged = c.filter(isChanged => {
       return isChanged !== undefined;
     }).reduce((a, b) => {


### PR DESCRIPTION
fix `verbose` and `lint` with folders

before:
```
csscomb -v ./src/
  ./src/styles/a.scss
✓ ./src/styles/b.scss
1 file processed
01,0 files fixed
```

After:
```
csscomb -v ./src/
  ./src/styles/a.scss
✓ ./src/styles/b.scss
2 files processed
1 file fixed
```