### PR TITLE
Fix bug in getSortablePropertyName for parse CSS custom properties (variables), #537

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     }
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.0.0"
   },
   "dependencies": {
     "babel-polyfill": "6.23.0",
     "glob": "latest",
-    "gonzales-pe": "^3.4.7",
+    "gonzales-pe": "^4.2.3",
     "minimatch": "3.0.2",
     "minimist": "1.1.x",
     "vow": "0.4.4",

--- a/src/options/sort-order.js
+++ b/src/options/sort-order.js
@@ -171,7 +171,8 @@ module.exports = {
 
   _getSortablePropertyName(node) {
     if (node.is('declaration')) {
-      let property = node.first('property').first();
+      let property =
+        node.first('property') ? node.first('property').first() : node.first();
       return property.is('variable') ? '$variable' : property.content;
     }
 

--- a/test/core/css/test.js
+++ b/test/core/css/test.js
@@ -1,0 +1,10 @@
+let Test = require('../core_test');
+
+describe('css', function() {
+    it('Should parse variables', function() {
+        let test = new Test(this);
+        test.comb.configure({});
+
+        return test.shouldBeEqual('variable.css');
+    });
+});

--- a/test/core/css/variable.css
+++ b/test/core/css/variable.css
@@ -1,0 +1,3 @@
+div {
+    --color: red;
+}


### PR DESCRIPTION
According to #537.
This PR also includes https://github.com/csscomb/csscomb.js/pull/566
Fixed - "TypeError: Cannot read property 'first' of null in _getSortablePropertyName"

Now CSS custom properties are parsed correctly 
