### PR TITLE
[cli] TTY-option type set to boolean

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -53,7 +53,7 @@ if (options['tty-mode'] || process.stdin.isTTY) {
 
 function getOptions() {
   var parserOptions = {
-    boolean: ['help', 'lint', 'verbose'],
+    boolean: ['help', 'lint', 'verbose', 'tty-mode'],
     alias: {
       config: 'c',
       detect: 'd',


### PR DESCRIPTION
TTY-mode option should be boolean, otherwise command:
```
csscomb -t path/to/file.css
```

will have options like:
```
{ _: [],
  t: 'path/to/file.css',
  'tty-mode': 'path/to/file.css'
}
```

when it should be:
```
{ _: ['path/to/file.css'],
  t: true,
  'tty-mode': true
}
```