### PR TITLE
Ignore leading combinators

### DIFF
--- a/src/options/space-before-combinator.js
+++ b/src/options/space-before-combinator.js
@@ -24,7 +24,10 @@ module.exports = {
 
     ast.traverseByType('combinator', function(combinator, i, parent) {
       var previousNode = parent.get(i - 1);
-      if (previousNode && previousNode.is('space')) {
+
+      if (!previousNode) return;
+
+      if (previousNode.is('space')) {
         previousNode.content = value;
       } else {
         var space = gonzales.createNode({

--- a/test/options/space-before-combinator/process/scss/test.expected.scss
+++ b/test/options/space-before-combinator/process/scss/test.expected.scss
@@ -1,0 +1,15 @@
+a  >b {
+  color: red;
+
+  &  >c {
+    color: red;
+  }
+}
+
+a {
+  color: red;
+
+  >c {
+    color: red;
+  }
+}

--- a/test/options/space-before-combinator/process/scss/test.scss
+++ b/test/options/space-before-combinator/process/scss/test.scss
@@ -1,0 +1,15 @@
+a>b {
+  color: red;
+
+  &>c {
+    color: red;
+  }
+}
+
+a {
+  color: red;
+
+  >c {
+    color: red;
+  }
+}

--- a/test/options/space-before-combinator/process/test.js
+++ b/test/options/space-before-combinator/process/test.js
@@ -32,4 +32,11 @@ describe('Option `space-before-combinator`, process', function() {
       return test.shouldBeEqual('test.css', 'test-3.expected.css');
     });
   });
+
+  describe('scss', function() {
+    it('Should not touch leading combinators', function() {
+      let test = new Test(this, {'space-before-combinator': '  '});
+      return test.shouldBeEqual('test.scss', 'test.expected.scss');
+    });
+  });
 });


### PR DESCRIPTION
In SCSS `space-before-combinator` should not touch leading/lone combinators as we can nested them:

```
.a> .b {
    > .b {
        prop: val;
    }
}
```

Should become (config: two spaces):

```
.a  > .b {
    > .b {
        prop: val;
    }
}
```

Not:

```
.a  > .b {
      > .b {
        prop: val;
    }
}
```

Related: #551 