### PR TITLE
Fix error when sorting leftover variable definitions. [closes #443]

### DIFF
--- a/src/options/sort-order.js
+++ b/src/options/sort-order.js
@@ -385,6 +385,14 @@ module.exports = {
     a = a.node.first().first().content;
     b = b.node.first().first().content;
 
+    if (Array.isArray(a)) {
+      a = a[0].content;
+    }
+
+    if (Array.isArray(b)) {
+      b = b[0].content;
+    }
+
     // Get prefix and unprefixed part. For example:
     // ['-o-animation', '-o-', 'animation']
     // ['color', '', 'color']

--- a/test/options/sort-order-fallback/process/scss/leftovers-variable.expected.scss
+++ b/test/options/sort-order-fallback/process/scss/leftovers-variable.expected.scss
@@ -1,0 +1,1 @@
+div {$blue: steelblue; $red: tomato;  }

--- a/test/options/sort-order-fallback/process/scss/leftovers-variable.scss
+++ b/test/options/sort-order-fallback/process/scss/leftovers-variable.scss
@@ -1,0 +1,1 @@
+div {$red: tomato;  $blue: steelblue; }

--- a/test/options/sort-order-fallback/process/test.js
+++ b/test/options/sort-order-fallback/process/test.js
@@ -41,4 +41,15 @@ describe('Option `sort-order-fallback`, process', function() {
       return test.shouldBeEqual('test.css', 'test-3.expected.css');
     });
   });
+
+  describe('scss', function() {
+    it('Should sort leftover variables alphabetically', function() {
+      let config = {
+        'sort-order': [],
+        'sort-order-fallback': 'abc'
+      };
+      let test = new Test(this, config);
+      return test.shouldBeEqual('leftovers-variable.scss', 'leftovers-variable.expected.scss');
+    });
+  });
 });

--- a/test/options/sort-order/process/scss/variable.expected.scss
+++ b/test/options/sort-order/process/scss/variable.expected.scss
@@ -1,1 +1,1 @@
-div {$red: tomato;  color: $tomato; }
+div {$red: tomato;  color: $red; }

--- a/test/options/sort-order/process/scss/variable.scss
+++ b/test/options/sort-order/process/scss/variable.scss
@@ -1,1 +1,1 @@
-div { color: $tomato; $red: tomato; }
+div { color: $red; $red: tomato; }


### PR DESCRIPTION
This PR fixes errors in sort-order option when sorting leftover variable definitions.
~~I still need to create a failing test.~~

**Update:**

Tests added.