### PR TITLE
Support new 'stdin-filepath' option

### DIFF
--- a/doc/usage-cli.md
+++ b/doc/usage-cli.md
@@ -18,6 +18,19 @@ If you installed the package locally, use local bin file instead:
 ./node_modules/.bin/csscomb assets/css public/styles.css
 ```
 
+`csscomb` also support `stdin` 
+
+```bash
+cat file.css | csscomb [options]
+```
+
+Which would output the result to `stdout`. Note that if the input content is not CSS, you should use `stdin-filepath` option.
+
+```bash
+cat style.less | csscomb --stdin-filepath style.less
+```
+
+
 ## Options
 
 ### help
@@ -38,6 +51,8 @@ csscomb -h
     -d, --detect         detect mode (would return detected options)
     -l, --lint           in case some fixes needed returns an error
     -t, --tty-mode       execution in TTY mode (useful, when running tool using external app, e.g. IDE)
+    --stdin-filepath
+        Path to the file to pretend that stdin comes from.
 ```
 
 ### config
@@ -99,4 +114,13 @@ csscomb -v assets/css
 4 files processed
 3 files fixed
 spent: 33ms
+```
+
+
+### stdin-filepath
+
+By default, `csscomb` would process content from `stdin` as css file. However, if your input is in different syntax (i.e `less`), you need to specify the file type information via the `stdin-filepath` options.
+
+```bash
+cat style.less | csscomb --stdin-filepath style.less
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,6 +60,7 @@ function getOptions() {
       lint: 'l',
       help: 'h',
       verbose: 'v',
+      'stdin-filepath': '',
       'tty-mode': 't'
     }
   };
@@ -88,6 +89,8 @@ function displayHelp() {
     '        Whether to print logging info.',
     '    -t, --tty-mode',
     '        Run the tool in TTY mode using external app (e.g. IDE).',
+    '    --stdin-filepath',
+    '        Path to the file to pretend that stdin comes from.',
     ''
   ];
   process.stdout.write(help.join(os.EOL));
@@ -182,7 +185,14 @@ function processSTDIN() {
 }
 
 function processInputData(input) {
-  comb.processString(input).catch(e => {
+  var opt
+  if (options["stdin-filepath"]) {
+    opt = {
+      syntax: comb._extractSyntax(options["stdin-filepath"])
+    }
+  }
+
+  comb.processString(input, opt).catch(e => {
     process.stderr.write(e.message);
     process.exit(1);
   }).then(output => {


### PR DESCRIPTION
The new `stdin-filepath` option would allow csscomb to process stdin that is in different syntax format (i.e. less). The detail of this new option could be viewed in the [doc/usage-cli.md](https://github.com/csscomb/csscomb.js/blob/8b63eae8b1639f730137742372be30b0fd98119f/doc/usage-cli.md)