### PR TITLE
Actually return promise in Comb::processFile

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -188,7 +188,7 @@ class Comb {
     return new Promise(resolve => {
       vfs.read(path, 'utf8').then(function(data) {
         let syntax = that._extractSyntax(path);
-        that.processString(data, {
+        return that.processString(data, {
           syntax: syntax,
           filename: path
         }).then(function(processedData) {


### PR DESCRIPTION
This makes it possible to catch exceptions in `processFiles` in
`cli.js`. Without this, node raises an error when promise throws an
exception:

    node:internal/process/promises:245
              triggerUncaughtException(err, true /* fromPromise */);
              ^

    [UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "[object Object]".] {
      code: 'ERR_UNHANDLED_REJECTION'
    }