### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.0",
-    "gonzales-pe": "4.2.4",
+    "gonzales-pe": "4.3.0",
     "minimatch": "3.0.4",
     "minimist": "1.2.0",
     "vow": "0.4.19",


### PR DESCRIPTION
Added latest gonzales-pe 4.3.0, as gonzales-pe 4.2.4 uses old  "dependencies": {
    "minimist": "1.1.x"
  },

which reported Vulnerability

Affected versions of minimist are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of Object, causing the addition or modification of an existing property that will exist on all objects.
Parsing the argument --__proto__.y=Polluted adds a y property with value Polluted to all objects. The argument --__proto__=Polluted raises and uncaught error and crashes the application.
This is exploitable if attackers have control over the arguments being passed to minimist. 